### PR TITLE
JSON version of the trace

### DIFF
--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -398,6 +398,7 @@ export class PrometheusDatasource
           });
           return {
             data: data.dataFrame,
+            trace: data.traceResult ? [data.traceResult] : [],
             key: query.requestId,
             state: runningQueriesCount === 0 ? LoadingState.Done : LoadingState.Loading,
           } as DataQueryResponse;

--- a/src/querybuilder/components/Trace/index.tsx
+++ b/src/querybuilder/components/Trace/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { DataQueryRequest, DataQueryResponse, PanelData } from "@grafana/data";
+import { Button, Modal, useStyles2 } from "@grafana/ui";
 
 import { Stack } from "../../../components/QueryEditor";
 import { PrometheusDatasource } from "../../../datasource";
@@ -8,6 +9,7 @@ import { PromQuery, TracingData } from "../../../types";
 
 import NestedNav from "./NestedNav/NestedNav";
 import Trace from "./Trace";
+import getStyles from './style'
 
 interface Props {
   query: PromQuery;
@@ -17,6 +19,38 @@ interface Props {
 
 export const TraceView = React.memo<Props>(({ query, data, datasource }) => {
   const [trace, setTrace] = useState<Trace | null>(null)
+  const [openModal, setOpenModal] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const styles = useStyles2(getStyles);
+
+  const handleOpenModal = () => {
+    setOpenModal(true)
+  }
+
+  const handleCloseModal = () => {
+    setOpenModal(false)
+  }
+
+  const handleCopyToClipboard = () => {
+    if (!trace || copied) {return}
+    navigator.clipboard.writeText(trace.JSON)
+    setCopied(true)
+  }
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null
+    if (copied) {
+      setTimeout(() => {
+        setCopied(false)
+      }, 2000)
+    }
+
+    return () => {
+      if (interval) {
+        clearInterval(interval)
+      }
+    }
+  }, [copied])
 
   useEffect(() => {
     const fetch = async () => {
@@ -41,16 +75,50 @@ export const TraceView = React.memo<Props>(({ query, data, datasource }) => {
     fetch()
   }, [data, datasource, query])
 
-  if (!trace) {return null}
+  if (!trace) {
+    return null
+  }
 
   return (
-    <Stack gap={0.5} direction="column">
+    <Stack gap={0} direction="column">
+      <div className={styles.header}>
+        <span>Trace for <b>{query.expr}</b></span>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleOpenModal}
+        >
+          Show JSON
+        </Button>
+      </div>
       <nav>
         <NestedNav
           trace={trace}
           totalMsec={trace.duration}
         />
       </nav>
+      <Modal
+        title={`Trace for ${query.expr}`}
+        isOpen={openModal}
+        closeOnEscape={true}
+        onDismiss={handleCloseModal}
+      >
+        <div>
+          <pre className={styles.json}>
+            <code lang="json">{trace.JSON}</code>
+          </pre>
+          <Modal.ButtonRow>
+            <Button
+              variant={copied ? "success" : "primary"}
+              size="sm"
+              onClick={handleCopyToClipboard}
+              icon={copied ? 'check' : 'copy'}
+            >
+              {copied ? 'Copied' : 'Copy JSON'}
+            </Button>
+          </Modal.ButtonRow>
+        </div>
+      </Modal>
     </Stack>
   );
 });

--- a/src/querybuilder/components/Trace/index.tsx
+++ b/src/querybuilder/components/Trace/index.tsx
@@ -46,16 +46,16 @@ export const TraceView = React.memo<Props>(({ query, data, datasource }) => {
   }
 
   useEffect(() => {
-    let interval: NodeJS.Timeout | null = null
+    let timeout: NodeJS.Timeout | null = null
     if (copied) {
-      interval = setTimeout(() => {
+      timeout = setTimeout(() => {
         setCopied(false)
       }, 2000)
     }
 
     return () => {
-      if (interval) {
-        clearInterval(interval)
+      if (timeout) {
+        clearInterval(timeout)
       }
     }
   }, [copied])

--- a/src/querybuilder/components/Trace/style.ts
+++ b/src/querybuilder/components/Trace/style.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from "@grafana/data";
+export default (theme: GrafanaTheme2) => ({
+  header: css({
+    display: 'grid',
+    gridTemplateColumns: "1fr auto",
+    alignItems: "center",
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.borderRadius(),
+    marginTop: theme.spacing(2),
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+  }),
+  json: css({
+    maxHeight: '50vh',
+    overflow: 'auto'
+  }),
+});

--- a/src/querybuilder/components/Trace/style.ts
+++ b/src/querybuilder/components/Trace/style.ts
@@ -15,4 +15,10 @@ export default (theme: GrafanaTheme2) => ({
     maxHeight: '50vh',
     overflow: 'auto'
   }),
+  error: css({
+    display: 'flex',
+    alignItems: 'center',
+    color: theme.colors.error.text,
+    gap: theme.spacing(1),
+  }),
 });


### PR DESCRIPTION
- Add a button to display and copy the JSON version of the trace. #53
- Show tracing on "Explore" page

<img width="600" alt="Screenshot 2023-03-02 at 21 09 48" src="https://user-images.githubusercontent.com/29711459/222541368-30471a6f-c769-4b11-b6a3-6cb5b1422a4f.png">

<img width="600" alt="Screenshot 2023-03-02 at 21 10 07" src="https://user-images.githubusercontent.com/29711459/222541360-07e63ff2-cec2-4808-ba99-d624099f9934.png">