### PR TITLE
Update README.md for Install in Kubernetes part

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ extraInitContainers:
      - "-c"
      - |
        set -ex
+       apk add --no-cache grep
        mkdir -p /var/lib/grafana/plugins/
        ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oP '\Kv\d+\.\d+\.\d+' | head -1)
        curl -L https://github.com/VictoriaMetrics/grafana-datasource/releases/download/$ver/victoriametrics-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/plugin.tar.gz


### PR DESCRIPTION
The BusyBox multi-call binary breaks the grep command as below: 
```
+ mkdir -p /var/lib/grafana/plugins/
+ curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest
+ grep -oP '\Kv\d+\.\d+\.\d+'
+ head -1
grep: unrecognized option: P
BusyBox v1.34.1 (2022-07-19 20:11:24 UTC) multi-call binary.
```
so, adding a  grep package.
```apk add --no-cache grep```