### PR TITLE
readme: fix usage of grep parameter which is not available in busybox

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Grafana docs can be found [here](https://grafana.com/docs/grafana/latest/setup-g
 2. To download plugin build and move contents into grafana plugins directory:
 
 ``` bash
-ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oP '\Kv\d+\.\d+\.\d+' | head -1)
+ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oE 'v\d+\.\d+\.\d+' | head -1)
 curl -L https://github.com/VictoriaMetrics/grafana-datasource/releases/download/$ver/victoriametrics-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/plugin.tar.gz
 tar -xf /var/lib/grafana/plugins/plugin.tar.gz -C /var/lib/grafana/plugins/
 rm /var/lib/grafana/plugins/plugin.tar.gz
@@ -57,7 +57,7 @@ extraInitContainers:
      - |
        set -ex
        mkdir -p /var/lib/grafana/plugins/
-       ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oP '\Kv\d+\.\d+\.\d+' | head -1)
+       ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oE 'v\d+\.\d+\.\d+' | head -1)
        curl -L https://github.com/VictoriaMetrics/grafana-datasource/releases/download/$ver/victoriametrics-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/plugin.tar.gz
        tar -xf /var/lib/grafana/plugins/plugin.tar.gz -C /var/lib/grafana/plugins/
        rm /var/lib/grafana/plugins/plugin.tar.gz


### PR DESCRIPTION
This PR removes usage of `-P` option in favor of `-E` which is supported in busybox and `curlimages/curl:7.85.0` images.
This is better than adding `grep` as it does not require having `root` access and doesn't increase startup time.

Supersedes: https://github.com/VictoriaMetrics/grafana-datasource/pull/64