### PR TITLE
feat: add support with templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## tip
 
+* FEATURE: add the ability to define expressions for each panel so that users can define WITH templates once and then reuse them. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/35).
 * FEATURE: add support MetricsQL to query builder. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/66).
-* FEATURE: Add the ability to change the link for [Run in VMUI](https://docs.victoriametrics.com/#vmui) button. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/61).
+* FEATURE: add the ability to change the link for [Run in VMUI](https://docs.victoriametrics.com/#vmui) button. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/61).
 
 * BUGFIX: fix the tracing display for Grafana version 9.4.
 

--- a/src/configuration/ConfigEditor.tsx
+++ b/src/configuration/ConfigEditor.tsx
@@ -29,6 +29,7 @@ import { AzureAuthSettings } from './AzureAuthSettings';
 import { hasCredentials, setDefaultCredentials, resetCredentials } from './AzureCredentialsConfig';
 import { PromSettings } from './PromSettings';
 import { TipsSetup } from "./TipsSetup";
+import WithTemplatesSettings from "./WithTemplateConfig/WithTemplatesSettings";
 
 export enum DataSourceType {
   Alertmanager = 'alertmanager',
@@ -63,13 +64,11 @@ export const ConfigEditor = (props: Props) => {
         renderSigV4Editor={<SIGV4ConnectionConfig {...props}></SIGV4ConnectionConfig>}
       />
 
-      <AlertingSettings<PromOptions>
-        alertmanagerDataSources={alertmanagers}
-        options={options}
-        onOptionsChange={onOptionsChange}
-      />
+      <AlertingSettings<PromOptions> alertmanagerDataSources={alertmanagers}{...props}/>
 
-      <PromSettings options={options} onOptionsChange={onOptionsChange}/>
+      <PromSettings {...props}/>
+
+      <WithTemplatesSettings  {...props}/>
     </>
   );
 };

--- a/src/configuration/WithTemplateConfig/DasboardItem/DashboardItem.tsx
+++ b/src/configuration/WithTemplateConfig/DasboardItem/DashboardItem.tsx
@@ -1,0 +1,60 @@
+import React, { FC, useCallback, useMemo, useState } from "react"
+
+import { Collapse, HorizontalGroup, Icon, useStyles2 } from "@grafana/ui";
+
+import TemplateEditor from "../TemplateEditor/TemplateEditor";
+import { DashboardType, WithTemplate } from "../types";
+
+import getStyles from "./style";
+
+interface Props {
+  index: number
+  dashboard: DashboardType
+  templates: WithTemplate[]
+  onChange: (template: WithTemplate) => void
+}
+
+const DashboardItem: FC<Props> = ({ dashboard, index, templates, onChange }) => {
+  const styles = useStyles2(getStyles);
+
+  const template = useMemo(() => {
+    return templates.find(t => t.uid === dashboard.uid) || { uid: dashboard.uid, expr: "" }
+  }, [templates, dashboard])
+
+  const [isOpen, setIsOpen] = useState(!index)
+  const handleToggleOpen = () => setIsOpen(prev => !prev)
+
+  const handleChange = useCallback((expr: string) => {
+    onChange({ uid: dashboard.uid, expr })
+  }, [onChange, dashboard.uid])
+
+  const handleChangeExpression = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+    handleChange(value)
+  }
+
+  return (
+    <Collapse
+      isOpen={isOpen}
+      onToggle={handleToggleOpen}
+      className={styles.collapse(index)}
+      label={(
+        <HorizontalGroup spacing={"sm"} justify="space-between">
+          <HorizontalGroup spacing={"sm"}>
+            <Icon name={"apps"}/>
+            <div>{dashboard.title}</div>
+          </HorizontalGroup>
+          <Icon name={isOpen ? "angle-up" : "angle-down"}/>
+        </HorizontalGroup>
+      )}
+    >
+    <div className={styles.template}>
+      <div>
+        <TemplateEditor value={template.expr} onChange={handleChangeExpression}/>
+      </div>
+    </div>
+    </Collapse>
+  )
+}
+
+export default DashboardItem

--- a/src/configuration/WithTemplateConfig/DasboardItem/style.ts
+++ b/src/configuration/WithTemplateConfig/DasboardItem/style.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from "@grafana/data";
+
+export default (theme: GrafanaTheme2) => ({
+  collapse: (i: number) => css`
+    margin: ${!i ? "0" : "-1px"} 0 0; 
+    border-radius: 0;
+  `,
+  template: css`
+    display: grid;
+    gap: ${theme.spacing(1)};
+  `,
+});

--- a/src/configuration/WithTemplateConfig/TemplateEditor/TemplateEditor.tsx
+++ b/src/configuration/WithTemplateConfig/TemplateEditor/TemplateEditor.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+
+import { TextArea } from "@grafana/ui";
+
+import { withTemplatePlaceholder } from "../constants";
+
+interface Props {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const TemplateEditor: FC<Props> = ({ value, onChange }) => {
+  // TODO add validate template
+
+  return (
+    <TextArea
+      rows={10}
+      value={value}
+      onChange={onChange}
+      spellCheck={false}
+      placeholder={withTemplatePlaceholder}
+    />
+  );
+}
+
+export default TemplateEditor;

--- a/src/configuration/WithTemplateConfig/WithTemplateTips/WithTemplateTips.tsx
+++ b/src/configuration/WithTemplateConfig/WithTemplateTips/WithTemplateTips.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { useStyles2 } from "@grafana/ui";
+
+import getStyles from "./style";
+
+const playgroundUrl = "https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/expand-with-exprs"
+
+const exampleWithExpr = `commonFilters = {instance=~"$node:$port",job=~"$job"},
+cpuCount = count(count(node_cpu_seconds_total{commonFilters}) by (cpu)),
+cpuIdle = sum(rate(node_cpu_seconds_total{mode='idle',commonFilters}[5m]))`
+
+const exampleUsage = `((cpuCount - cpuIdle) * 100) / cpuCount`
+
+const exampleFullQuery = `WITH (
+${exampleWithExpr}
+) 
+${exampleUsage}`
+
+const WithTemplateTips = () => {
+
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.wrapper}>
+      <p className={styles.paragraph}>
+        This feature simplifies writing and managing complex queries.
+        Go to <a className="text-link" href={playgroundUrl}>WITH templates playground</a> and try it.
+      </p>
+      <p className={styles.paragraph}>
+        The <code>WITH templates</code> settings section allows you to create expressions with templates that can be used in
+        dashboards to create flexible and adaptive queries for metrics.
+      </p>
+
+      <div className={styles.section}>
+        <h6>
+          <b>Configuration:</b>
+        </h6>
+        <p className={styles.paragraph}>
+          <ol>
+            <li>Open the datasource settings and find the <code>WITH templates</code> section.</li>
+            <li>Find the dashboard for which you want to add a with template expression.</li>
+            <li>
+              Enter the expression in the input field:
+              <pre><code>{exampleWithExpr}</code></pre>
+            </li>
+            <li>Save the datasource changes.</li>
+            <li>
+              Open the panel inside the dashboard for which you created the with template expression
+              and enter the query in the input field:
+              <pre><code>{exampleUsage}</code></pre>
+            </li>
+            <li>
+              Thus, the entire query will look as follows:
+              <pre><code>{exampleFullQuery}</code></pre>
+              To view the raw query in the interface, enable the <code>Raw</code> toggle.
+            </li>
+          </ol>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default WithTemplateTips;

--- a/src/configuration/WithTemplateConfig/WithTemplateTips/style.ts
+++ b/src/configuration/WithTemplateConfig/WithTemplateTips/style.ts
@@ -1,0 +1,22 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from "@grafana/data";
+
+export default (theme: GrafanaTheme2) => ({
+  wrapper: css`
+    padding: ${theme.spacing(2)} 0;
+    max-width: 800px;
+  `,
+  section: css`
+    margin: ${theme.spacing(2)} 0;
+  `,
+  paragraph: css`
+    margin: ${theme.spacing(1)} 0;
+    font-size: ${theme.typography.fontSize};
+    line-height: 150%;
+    
+    ol {
+      padding-left: ${theme.spacing(2)};
+    }
+  `,
+});

--- a/src/configuration/WithTemplateConfig/WithTemplatesSettings.tsx
+++ b/src/configuration/WithTemplateConfig/WithTemplatesSettings.tsx
@@ -1,0 +1,106 @@
+import { groupBy } from 'lodash';
+import React, { FC, useEffect, useMemo, useState } from 'react';
+
+import { DataSourcePluginOptionsEditorProps } from "@grafana/data";
+import { HorizontalGroup, Icon, Tab, TabContent, TabsBar, useStyles2 } from "@grafana/ui";
+
+import { PromOptions } from "../../types";
+
+import DashboardItem from "./DasboardItem/DashboardItem";
+import WithTemplateTips from "./WithTemplateTips/WithTemplateTips";
+import getDashboardList from "./api/getDashboardList";
+import { generalFolderTitle, infoTab } from "./constants";
+import getStyles from "./style";
+import { DashboardType, WithTemplate } from "./types";
+
+type Props = DataSourcePluginOptionsEditorProps<PromOptions>;
+const WithTemplatesSettings: FC<Props> = (props) => {
+  const { options, onOptionsChange } = props;
+
+  const styles = useStyles2(getStyles);
+
+  const templates = useMemo(() => options.jsonData.withTemplates || [], [options.jsonData])
+
+  const [dashboards, setDashboards] = useState<Record<string, DashboardType[]>>({})
+  const [openFolder, setOpenFolder] = useState(generalFolderTitle)
+  const [loading, setLoading] = useState(false)
+
+  const handleSaveTemplate = (template: WithTemplate) => {
+    const oldTemplates = templates.filter(t => t.uid !== template.uid)
+    const withTemplates = [...oldTemplates, template]
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        withTemplates,
+      },
+    })
+  }
+  const handleChangeTab = (folderTitle: string) => (e?: React.MouseEvent<HTMLAnchorElement>) => {
+    e?.preventDefault()
+    setOpenFolder(folderTitle)
+  }
+
+  useEffect(() => {
+    const fetchDashboards = async () => {
+      setLoading(true)
+      try {
+        const dashboardsData = await getDashboardList()
+        const groupByFolder = groupBy(dashboardsData, 'folderTitle')
+        setDashboards(groupByFolder)
+      } catch (error) {
+        console.error('Error fetching dashboards:', error);
+      }
+      setLoading(false)
+    }
+
+    fetchDashboards()
+  }, [])
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <HorizontalGroup spacing="xs">
+          <h3 className="page-heading">WITH templates</h3>
+          {loading && <Icon name="fa fa-spinner"/>}
+        </HorizontalGroup>
+      </div>
+      <div>
+        <TabsBar>
+          <Tab
+            label={infoTab.label}
+            active={infoTab.id === openFolder}
+            onChangeTab={handleChangeTab(infoTab.id)}
+            icon={infoTab.icon}
+          />
+          {Object.keys(dashboards).map(folderTitle => (
+            <Tab
+              key={folderTitle}
+              label={folderTitle}
+              active={folderTitle === openFolder}
+              onChangeTab={handleChangeTab(folderTitle)}
+              icon={folderTitle === openFolder ? "folder-open" : "folder"}
+            />
+          ))}
+        </TabsBar>
+        <TabContent>
+          <div>
+            {dashboards[openFolder]?.map((dashboard, i) => (
+              <DashboardItem
+                index={i}
+                key={dashboard.uid}
+                dashboard={dashboard}
+                templates={templates}
+                onChange={handleSaveTemplate}
+              />
+            ))}
+            {openFolder === infoTab.id && <WithTemplateTips/>}
+          </div>
+        </TabContent>
+      </div>
+    </div>
+  );
+}
+
+export default WithTemplatesSettings
+

--- a/src/configuration/WithTemplateConfig/api/getDashboardList.ts
+++ b/src/configuration/WithTemplateConfig/api/getDashboardList.ts
@@ -1,0 +1,19 @@
+import { lastValueFrom } from "rxjs";
+
+import { getBackendSrv } from "@grafana/runtime";
+
+import { generalFolderTitle } from "../constants";
+import { DashboardType, DashTypes } from "../types";
+
+const getDashboardList = async (): Promise<DashboardType[]> => {
+  const response = await lastValueFrom(await getBackendSrv().fetch({
+    url: `/api/search?type=${DashTypes.DASHBOARD}&query=&`,
+    method: 'GET',
+  }));
+
+  return ((response?.data || []) as DashboardType[])
+    .sort((a, b) => (a.folderTitle || "").localeCompare(b.folderTitle || ""))
+    .map(d => ({ ...d, folderTitle: d.folderTitle || generalFolderTitle }))
+}
+
+export default getDashboardList

--- a/src/configuration/WithTemplateConfig/constants.tsx
+++ b/src/configuration/WithTemplateConfig/constants.tsx
@@ -1,0 +1,16 @@
+import { IconName } from "@grafana/ui";
+
+export const generalFolderTitle = "General"
+
+export const withTemplateTip = `The WITH templates settings section allows you to create global templates 
+and variables (with template expressions) that can be used in specific dashboards to create flexible 
+and adaptive queries for metrics.`
+
+export const withTemplatePlaceholder = `commonFilters = {instance=~"$node:$port",job=~"$job"},
+cpuCount = count(count(node_cpu_seconds_total{commonFilters}) by (cpu))`
+
+export const infoTab = {
+  id: "info",
+  label: "How it works",
+  icon: "info-circle" as IconName,
+}

--- a/src/configuration/WithTemplateConfig/style.ts
+++ b/src/configuration/WithTemplateConfig/style.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from "@grafana/data";
+
+export default (theme: GrafanaTheme2) => ({
+  wrapper: css`
+    display: grid;
+    gap: ${theme.spacing(1)};
+  `,
+  header: css`
+    display: flex;
+    gap: ${theme.spacing(1)};
+    align-items: center;
+    
+    h3 {margin: 0;}
+  `,
+});

--- a/src/configuration/WithTemplateConfig/types.ts
+++ b/src/configuration/WithTemplateConfig/types.ts
@@ -1,0 +1,26 @@
+export enum DashTypes {
+  FOLDER = 'dash-folder',
+  DASHBOARD = 'dash-db',
+}
+
+export interface WithTemplate {
+  uid: string;
+  expr: string;
+}
+
+export interface DashboardType {
+  id: number;
+  uid: string;
+  title: string;
+  uri: string;
+  url: string;
+  slug: string;
+  type: 'dash-db';
+  tags: string[];
+  isStarred: boolean;
+  sortMeta: number;
+  folderId?: number;
+  folderUid?: string;
+  folderTitle?: string;
+  folderUrl?: string;
+}

--- a/src/configuration/WithTemplateConfig/utils/getArrayFromTemplate.ts
+++ b/src/configuration/WithTemplateConfig/utils/getArrayFromTemplate.ts
@@ -1,0 +1,31 @@
+import { WithTemplate } from "../types";
+
+import splitByCommaOutsideBrackets from "./splitByCommaOutsideBrackets";
+
+export const getArrayFromTemplate = (template?: WithTemplate) => {
+  if (!template) {return []}
+  const { expr } = template
+  const arr = splitByCommaOutsideBrackets(expr)
+  return arr.filter(a => a).map(a => ({
+    label: a.split("=")[0].trim().replace(/\(.+\)/, ""),
+    value: a.trim()
+  }))
+}
+
+export const formatTemplateString = (expr: string) => {
+  const arr = getArrayFromTemplate({ expr, uid: '' })
+  const values = arr.map(a => a.value)
+  return values.join(',\n')
+}
+
+export const mergeTemplateWithQuery = (query = "", template?: WithTemplate) => {
+  const templateExpr = template?.expr
+  if (!templateExpr) {return query}
+  const labels = getArrayFromTemplate(template).map(a => a.label)
+  const includesWithTemplate = labels.some(l => query.includes(l))
+  if (!includesWithTemplate) {return query}
+  return `WITH(
+  ${formatTemplateString(templateExpr)}
+)
+${query}`
+}

--- a/src/configuration/WithTemplateConfig/utils/splitByCommaOutsideBrackets.ts
+++ b/src/configuration/WithTemplateConfig/utils/splitByCommaOutsideBrackets.ts
@@ -1,0 +1,30 @@
+const isOpeningBracket = (char: string): boolean => ['(', '{', '['].includes(char);
+const isClosingBracket = (char: string): boolean => [')', '}', ']'].includes(char);
+const isQuote = (char: string): boolean => ['"', "'"].includes(char);
+
+const shouldSplit = (char: string, bracketsCount: number, quotesCount: number): boolean =>
+  char === ',' && bracketsCount === 0 && quotesCount % 2 === 0;
+
+const splitByCommaOutsideBrackets = (str: string): string[] => {
+  let bracketsCount = 0;
+  let quotesCount = 0;
+
+  return str.split('').reduce((result: string[], char: string) => {
+    if (isQuote(char)) {quotesCount++;}
+
+    if (quotesCount % 2 === 0) {
+      if (isOpeningBracket(char)) {bracketsCount++;}
+      if (isClosingBracket(char)) {bracketsCount--;}
+    }
+
+    if (shouldSplit(char, bracketsCount, quotesCount)) {
+      result.push('');
+    } else {
+      result[result.length - 1] += char;
+    }
+
+    return result;
+  }, ['']);
+};
+
+export default splitByCommaOutsideBrackets;

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -55,6 +55,8 @@ import {
 } from '@grafana/runtime';
 
 import { addLabelToQuery } from './add_label_to_query';
+import { WithTemplate } from "./configuration/WithTemplateConfig/types";
+import { mergeTemplateWithQuery } from "./configuration/WithTemplateConfig/utils/getArrayFromTemplate";
 import { ANNOTATION_QUERY_STEP_DEFAULT, DATASOURCE_TYPE } from "./consts";
 import PrometheusLanguageProvider from './language_provider';
 import { expandRecordingRules } from './language_utils';
@@ -107,6 +109,7 @@ export class PrometheusDatasource
   exemplarsAvailable: boolean;
   subType: PromApplication;
   rulerEnabled: boolean;
+  withTemplates: WithTemplate[];
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<PromOptions>,
@@ -137,6 +140,7 @@ export class PrometheusDatasource
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
     this.variables = new PrometheusVariableSupport(this, this.templateSrv, this.timeSrv);
     this.exemplarsAvailable = false;
+    this.withTemplates = instanceSettings.jsonData.withTemplates ?? [];
   }
 
   init = async () => {
@@ -509,6 +513,11 @@ export class PrometheusDatasource
 
     // Apply adhoc filters
     expr = this.enhanceExprWithAdHocFilters(expr);
+
+    // Apply WITH templates
+    // @ts-ignore
+    const dashboardUID = options.dashboardUID
+    expr = mergeTemplateWithQuery(expr, this.withTemplates.find(t => t.uid === dashboardUID))
 
     // Only replace vars in expression after having (possibly) updated interval vars
     query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);

--- a/src/querybuilder/components/PromQueryBuilderContainer.tsx
+++ b/src/querybuilder/components/PromQueryBuilderContainer.tsx
@@ -28,8 +28,6 @@ import { buildVisualQueryFromString } from '../parsing';
 import { PromVisualQuery } from '../types';
 
 import { PromQueryBuilder } from './PromQueryBuilder';
-import { QueryPreview } from './QueryPreview';
-import { TraceView } from "./Trace";
 
 export interface Props {
   query: PromQuery;
@@ -37,9 +35,7 @@ export interface Props {
   onChange: (update: PromQuery) => void;
   onRunQuery: () => void;
   data?: PanelData;
-  showRawQuery?: boolean;
   showExplain: boolean;
-  showTrace: boolean;
 }
 
 export interface State {
@@ -51,7 +47,7 @@ export interface State {
  * This component is here just to contain the translation logic between string query and the visual query builder model.
  */
 export function PromQueryBuilderContainer(props: Props) {
-  const { query, onChange, onRunQuery, datasource, data, showRawQuery, showExplain, showTrace } = props;
+  const { query, onChange, onRunQuery, datasource, data, showExplain } = props;
   const [state, dispatch] = useReducer(stateSlice.reducer, { expr: query.expr });
 
   // Only rebuild visual query if expr changes from outside
@@ -79,8 +75,6 @@ export function PromQueryBuilderContainer(props: Props) {
         data={data}
         showExplain={showExplain}
       />
-      {showRawQuery && <QueryPreview query={query.expr} />}
-      {showTrace && <TraceView query={query} datasource={datasource} data={data} />}
     </>
   );
 }

--- a/src/querybuilder/components/PromQueryCodeEditor.test.tsx
+++ b/src/querybuilder/components/PromQueryCodeEditor.test.tsx
@@ -45,14 +45,14 @@ describe('PromQueryCodeEditor', () => {
     const { datasource } = createDatasource();
     const props = createProps(datasource);
     props.showExplain = true;
-    render(<PromQueryCodeEditor {...props} showTrace={false} query={{ expr: '', refId: 'refid', interval: '1s' }} />);
+    render(<PromQueryCodeEditor {...props} query={{ expr: '', refId: 'refid', interval: '1s' }} />);
     expect(await screen.findByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 
   it('does not show explain section when showExplain is false', async () => {
     const { datasource } = createDatasource();
     const props = createProps(datasource);
-    render(<PromQueryCodeEditor {...props} showTrace={false} query={{ expr: '', refId: 'refid', interval: '1s' }} />);
+    render(<PromQueryCodeEditor {...props} query={{ expr: '', refId: 'refid', interval: '1s' }} />);
     expect(await screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 });

--- a/src/querybuilder/components/PromQueryCodeEditor.tsx
+++ b/src/querybuilder/components/PromQueryCodeEditor.tsx
@@ -25,33 +25,23 @@ import PromQueryField from '../../components/PromQueryField';
 import { PromQueryEditorProps } from '../../components/types';
 
 import { PromQueryBuilderExplained } from './PromQueryBuilderExplained';
-import { TraceView } from "./Trace";
 
 type Props = PromQueryEditorProps & {
   showExplain: boolean;
-  showTrace: boolean;
 };
 
-export function PromQueryCodeEditor(props: Props) {
-  const { query, datasource, range, onRunQuery, onChange, data, app, showExplain, showTrace } = props;
+export function PromQueryCodeEditor({ query, showExplain, ...props }: Props) {
   const styles = useStyles2(getStyles);
-
   return (
     <div className={styles.wrapper}>
       <PromQueryField
-        datasource={datasource}
+        {...props}
         query={query}
-        range={range}
-        onRunQuery={onRunQuery}
-        onChange={onChange}
         history={[]}
-        data={data}
         data-testid={'prom-editor'}
-        app={app}
       />
 
       {showExplain && <PromQueryBuilderExplained query={query.expr} />}
-      {showTrace && <TraceView query={query} datasource={datasource} data={data} />}
     </div>
   );
 }

--- a/src/querybuilder/components/QueryPreview.tsx
+++ b/src/querybuilder/components/QueryPreview.tsx
@@ -19,19 +19,25 @@
 import React from 'react';
 
 import { EditorRow, EditorFieldGroup, EditorField } from '../../components/QueryEditor';
+import { WithTemplate } from "../../configuration/WithTemplateConfig/types";
+import { mergeTemplateWithQuery } from "../../configuration/WithTemplateConfig/utils/getArrayFromTemplate";
 import metricsqlGrammar from '../../metricsql';
 import { RawQuery } from '../shared/RawQuery';
 
 export interface Props {
   query: string;
+  withTemplate?: WithTemplate
 }
 
-export function QueryPreview({ query }: Props) {
+export function QueryPreview({ query, withTemplate }: Props) {
   return (
     <EditorRow>
       <EditorFieldGroup>
         <EditorField label="Raw query">
-          <RawQuery query={query} lang={{ grammar: metricsqlGrammar, name: 'promql' }} />
+          <RawQuery
+            query={mergeTemplateWithQuery(query, withTemplate)}
+            lang={{ grammar: metricsqlGrammar, name: 'promql' }}
+          />
         </EditorField>
       </EditorFieldGroup>
     </EditorRow>

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@
 
 import { DataQuery, DataSourceJsonData, QueryResultMeta, ScopedVars } from '@grafana/data';
 
+import { WithTemplate } from "./configuration/WithTemplateConfig/types";
 import { QueryEditorMode } from './querybuilder/shared/types';
 
 export interface PromQuery extends DataQuery {
@@ -50,6 +51,7 @@ export interface PromOptions extends DataSourceJsonData {
   customQueryParameters?: string;
   disableMetricsLookup?: boolean;
   exemplarTraceIdDestinations?: ExemplarTraceIdDestination[];
+  withTemplates?: WithTemplate[];
 }
 
 export enum PromQueryType {


### PR DESCRIPTION
Add the ability to define WITH templates once and then reuse them.
To start, open the datasource settings and find the WITH template section.

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/29711459/236705862-f0730068-95fa-4905-8d2a-acf2a2fe206c.png">


#35