### PR TITLE
fix: fix label_values template functions behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * FEATURE: Add the ability to change the link for [Run in VMUI](https://docs.victoriametrics.com/#vmui) button. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/61).
 
 * BUGFIX: fix the tracing display for Grafana version 9.4.
-* BUGFIX: fix parsing params from `label_values()` grafana template function. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/74).
+* BUGFIX: support label with dots in names for template function `label_values()`. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/74).
 
 ## [v0.1.3](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.1.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * FEATURE: Add the ability to change the link for [Run in VMUI](https://docs.victoriametrics.com/#vmui) button. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/61).
 
 * BUGFIX: fix the tracing display for Grafana version 9.4.
+* BUGFIX: fix parsing params from `label_values()` grafana template function. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/74).
 
 ## [v0.1.3](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.1.3)
 

--- a/src/metric_find_query.ts
+++ b/src/metric_find_query.ts
@@ -37,7 +37,7 @@ export default class PrometheusMetricFindQuery {
 
   process(): Promise<MetricFindValue[]> {
     const labelNamesRegex = /^label_names\(\)\s*$/;
-    const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+    const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_\\.][a-zA-Z0-9_\\.]*)\)\s*$/;
     const metricNamesRegex = /^metrics\((.+)\)\s*$/;
     const queryResultRegex = /^query_result\((.+)\)\s*$/;
     const labelNamesQuery = this.query.match(labelNamesRegex);


### PR DESCRIPTION
Expand regex for `label_values` template function.  Added support to get values from the next queries `label_values(my.label)` or `label_values(my\.label)`
<img width="555" alt="Screenshot 2023-05-24 at 10 20 00" src="https://github.com/VictoriaMetrics/grafana-datasource/assets/12189570/2b3dc2c0-68fd-4f5f-b6a7-01c8d1f4d629">

Related issue: https://github.com/VictoriaMetrics/grafana-datasource/issues/74

