### PR TITLE
improvements to WITH Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## tip
 
+* FEATURE: Improvements to WITH Templates (see [this comment](https://github.com/VictoriaMetrics/grafana-datasource/issues/35#issuecomment-1578649762)):
+  - Improved display of templates in auto-complete hints;
+  - Enabled auto-complete within curly braces for filters defined in templates;
+  - Added support for Grafana variables such as `$__interval`, `$__rate_interval`, etc. in WITH expression validation.
+
 ## [v0.2.1](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.2.1)
 
 * BUGFIX: respect the time filter change on updating dashboard variables. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/47)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 The VictoriaMetrics data source plugin allows you to query and visualize VictoriaMetrics
 data from within Grafana.
 
+* [Motivation](#motivation)
+* [Installation](#installation)
+* [Configure the Datasource with Provisioning](#configure-the-datasource-with-provisioning)
+* [Getting started development](#configure-the-datasource-with-provisioning)
+* [How to make new release](#how-to-make-new-release)
+* [How to use WITH templates](#how-to-make-new-release)
+* [Learn more](#learn-more)
+* [License](#license)
+
 ## Motivation
 
 VictoriaMetrics always recommended using [Prometheus datasource](https://docs.victoriametrics.com/#grafana-setup)
@@ -239,6 +248,53 @@ parts into `dist` folder.
 4. Go to <https://github.com/VictoriaMetrics/grafana-datasource/releases> and verify that draft release with the name `TAG` has been created
    and this release contains all the needed binaries and checksums.
 5. Remove the `draft` checkbox for the `TAG` release and manually publish it.
+
+## How to use WITH templates
+
+The `WITH` templates feature simplifies the construction and management of complex queries.
+You can try this feature in the [WITH templates playground](https://play.victoriametrics.com/select/accounting/1/6a716b0f-38bc-4856-90ce-448fd713e3fe/expand-with-exprs).
+
+The "WITH templates" settings section allows you to create expressions with templates that can be used in dashboards.
+
+### Defining WITH Expressions
+
+1. Open the datasource settings. Scroll to the bottom of the page and find the "WITH templates" section.
+2. Find the dashboard for which you want to add a `WITH` template expression.
+3. Enter the expression in the input field. Once done, press the `Save` button on the datasource to apply the changes. For example:
+   ```
+   commonFilters = {instance=~"$node:$port",job=~"$job"},
+   
+   # `cpuCount` is the number of CPUs on the node
+   cpuCount = count(count(node_cpu_seconds_total{commonFilters}) by (cpu)),
+   
+   # `cpuIdle` is the sum of idle CPU cores
+   cpuIdle = sum(rate(node_cpu_seconds_total{mode='idle',commonFilters}[5m]))
+   ```
+
+You can specify a comment before the variable and use markdown in it. The comment will be displayed as a hint during auto-completion. The comment can span multiple lines.
+
+The expression will be validated when the input field loses focus and the validation result will be displayed below the input field.
+
+### Using WITH Expressions
+
+1. Open the panel inside the dashboard for which you created the expression. As you type your query, auto-complete hints will appear, including the expressions you've defined.
+2. You can also see all the defined expressions for the current panel by clicking on the `WITH templates` button on the page.
+3. Enter the query in the input field:
+   ```
+   ((cpuCount - cpuIdle) * 100) / cpuCount
+   ```
+   
+   Thus, the entire query will look as follows:
+    
+   ```
+   WITH (
+    commonFilters = {instance=~"$node:$port",job=~"$job"},
+    cpuCount = count(count(node_cpu_seconds_total{commonFilters}) by (cpu)),
+    cpuIdle = sum(rate(node_cpu_seconds_total{mode='idle',commonFilters}[5m]))
+   )
+   ((cpuCount - cpuIdle) * 100) / cpuCount
+   ```
+   To view the raw query in the interface, enable the `Raw` toggle.
 
 ## Learn more
 

--- a/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -158,8 +158,7 @@ const MonacoQueryField = (props: Props) => {
             Promise.resolve(historyRef.current.map((h) => h.query.expr).filter((expr) => expr !== undefined));
 
           const getAllMetricNames = () => {
-            const { metrics, metricsMetadata, withTemplates } = lpRef.current;
-            const templates = withTemplates.map(t => ({ name: t.label, help: t.value, type: "WITH template" }))
+            const { metrics, metricsMetadata } = lpRef.current;
             const result = metrics.map((m) => {
               const metaItem = metricsMetadata?.[m];
               return {
@@ -167,7 +166,18 @@ const MonacoQueryField = (props: Props) => {
                 help: metaItem?.help ?? '',
                 type: metaItem?.type ?? '',
               };
-            }).concat(templates);
+            });
+
+            return Promise.resolve(result);
+          };
+
+          const getAllWithTemplates = () => {
+            const { withTemplates } = lpRef.current;
+            const result = withTemplates.map(t => ({
+              name: t.label,
+              help: t.comment || "",
+              value: t.value
+            }))
 
             return Promise.resolve(result);
           };
@@ -176,7 +186,14 @@ const MonacoQueryField = (props: Props) => {
 
           const getLabelValues = (labelName: string) => lpRef.current.getLabelValues(labelName);
 
-          const dataProvider = { getSeries, getHistory, getAllMetricNames, getAllLabelNames, getLabelValues };
+          const dataProvider = {
+            getSeries,
+            getHistory,
+            getAllMetricNames,
+            getAllWithTemplates,
+            getAllLabelNames,
+            getLabelValues
+          };
           const completionProvider = getCompletionProvider(monaco, dataProvider);
 
           // completion-providers in monaco are not registered directly to editor-instances,

--- a/src/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -59,6 +59,8 @@ function getMonacoCompletionItemKind(type: CompletionType, monaco: Monaco): mona
       return monaco.languages.CompletionItemKind.EnumMember;
     case 'METRIC_NAME':
       return monaco.languages.CompletionItemKind.Constructor;
+    case 'WITH_TEMPLATE':
+      return monaco.languages.CompletionItemKind.Constant;
     default:
       throw new NeverCaseError();
   }

--- a/src/configuration/WithTemplateConfig/utils/getArrayFromTemplate.ts
+++ b/src/configuration/WithTemplateConfig/utils/getArrayFromTemplate.ts
@@ -6,10 +6,20 @@ export const getArrayFromTemplate = (template?: WithTemplate) => {
   if (!template) {return []}
   const { expr } = template
   const arr = splitByCommaOutsideBrackets(expr)
-  return arr.filter(a => a).map(a => ({
-    label: a.split("=")[0].trim().replace(/\(.+\)/, ""),
-    value: a.trim()
-  }))
+
+  return arr.filter(a => a).map(a => {
+    const commentMatch = a.match(/#.*\n/gm);
+    const comment = commentMatch ? commentMatch.join('').trim() : '';
+
+    const variableMatch = a.match(/(.*?)=/);
+    const variableName = variableMatch ? variableMatch[0].slice(0, -2) : '';
+
+    return {
+      label: `${variableName}`,
+      comment: comment.replace(/#/gm, ''),
+      value: a.replace(comment, '').trim(),
+    }
+  })
 }
 
 export const formatTemplateString = (expr: string) => {

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -108,7 +108,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   datasource: PrometheusDatasource;
   labelKeys: string[] = [];
   declare labelFetchTs: number;
-  withTemplates: Array<{label: string, value: string}>
+  withTemplates: Array<{label: string, comment: string, value: string}>
 
   /**
    *  Cache for labels of series. This is bit simplistic in the sense that it just counts responses each as a 1 and does

--- a/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -113,6 +113,7 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
   useEffect(() => {
     const withTemplates = getArrayFromTemplate(withTemplate)
     datasource.languageProvider = new PrometheusLanguageProvider(datasource, { withTemplates })
+    datasource.languageProvider.start()
   }, [datasource, withTemplate])
 
   return (


### PR DESCRIPTION
- Improved display of templates in auto-complete hints;
- Enabled auto-complete within curly braces for filters defined in templates;
- Added support for Grafana variables such as `$__interval`, `$__rate_interval`, etc. in WITH expression validation.
- Added docs to README explaining how to use WITH templates

<img width="699" alt="Screenshot 2023-07-19 at 15 43 17" src="https://github.com/VictoriaMetrics/grafana-datasource/assets/29711459/9d69bc43-b43e-4b16-80ee-0b2969a706db">
<img width="699" alt="Screenshot 2023-07-19 at 15 42 51" src="https://github.com/VictoriaMetrics/grafana-datasource/assets/29711459/d21bf529-5ac9-4afa-93bc-a9529e798bb3">

Reference https://github.com/VictoriaMetrics/grafana-datasource/issues/35#issuecomment-1578649762