### PR TITLE
fix: handle custom query params in annotation queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: correctly handle custom query parameters in annotation queries. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/95)
+
 ## [v0.3.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.3.0)
 
 * FEATURE: Improvements to WITH Templates (see [this comment](https://github.com/VictoriaMetrics/grafana-datasource/issues/35#issuecomment-1578649762)):

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -88,18 +88,20 @@ func (d *Datasource) query(ctx context.Context, query backend.DataQuery) backend
 		return newResponseError(err, backend.StatusBadRequest)
 	}
 
-	reqURL, err := q.getQueryURL(minInterval, d.settings.URL)
-	if err != nil {
-		err = fmt.Errorf("failed to create request url: %w", err)
-		return newResponseError(err, backend.StatusBadRequest)
-	}
-
 	httpMethod := http.MethodPost
 	var settingsData struct {
-		HTTPMethod string `json:"httpMethod"`
+		HTTPMethod            string `json:"httpMethod"`
+		CustomQueryParameters string `json:"customQueryParameters"`
 	}
 	if err := json.Unmarshal(d.settings.JSONData, &settingsData); err == nil && settingsData.HTTPMethod != "" {
 		httpMethod = settingsData.HTTPMethod
+	}
+	customQueryParameters := settingsData.CustomQueryParameters
+
+	reqURL, err := q.getQueryURL(minInterval, d.settings.URL, customQueryParameters)
+	if err != nil {
+		err = fmt.Errorf("failed to create request url: %w", err)
+		return newResponseError(err, backend.StatusBadRequest)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, httpMethod, reqURL, nil)

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -37,7 +37,7 @@ type TimeRange struct {
 
 // GetQueryURL calculates step and clear expression from template variables,
 // and after builds query url depends on query type
-func (q *Query) getQueryURL(minInterval time.Duration, rawURL string) (string, error) {
+func (q *Query) getQueryURL(minInterval time.Duration, rawURL string, customQueryParams string) (string, error) {
 	if rawURL == "" {
 		return "", fmt.Errorf("url can't be blank")
 	}
@@ -59,9 +59,9 @@ func (q *Query) getQueryURL(minInterval time.Duration, rawURL string) (string, e
 	}
 
 	if q.Instant {
-		return q.queryInstantURL(expr, step), nil
+		return q.queryInstantURL(expr, step, customQueryParams), nil
 	}
-	return q.queryRangeURL(expr, step), nil
+	return q.queryRangeURL(expr, step, customQueryParams), nil
 }
 
 // withIntervalVariable checks does query has interval variable
@@ -79,7 +79,7 @@ func (q *Query) calculateMinInterval() (time.Duration, error) {
 }
 
 // queryInstantURL prepare query url for instant query
-func (q *Query) queryInstantURL(expr string, step time.Duration) string {
+func (q *Query) queryInstantURL(expr string, step time.Duration, customQueryParams string) string {
 	q.url.Path = path.Join(q.url.Path, instantQueryPath)
 	values := q.url.Query()
 
@@ -88,11 +88,14 @@ func (q *Query) queryInstantURL(expr string, step time.Duration) string {
 	values.Add("step", step.String())
 
 	q.url.RawQuery = values.Encode()
+	if customQueryParams != "" {
+		q.url.RawQuery += "&" + customQueryParams
+	}
 	return q.url.String()
 }
 
 // queryRangeURL prepare query url for range query
-func (q *Query) queryRangeURL(expr string, step time.Duration) string {
+func (q *Query) queryRangeURL(expr string, step time.Duration, customQueryParams string) string {
 	q.url.Path = path.Join(q.url.Path, rangeQueryPath)
 	values := q.url.Query()
 
@@ -102,6 +105,9 @@ func (q *Query) queryRangeURL(expr string, step time.Duration) string {
 	values.Add("step", step.String())
 
 	q.url.RawQuery = values.Encode()
+	if customQueryParams != "" {
+		q.url.RawQuery += "&" + customQueryParams
+	}
 	return q.url.String()
 }
 

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -150,7 +150,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 				TimeRange:     tt.fields.getTimeRange(),
 				url:           tt.fields.url,
 			}
-			got, err := q.getQueryURL(tt.args.minInterval, tt.args.rawURL)
+			got, err := q.getQueryURL(tt.args.minInterval, tt.args.rawURL, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getQueryURL() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/src/configuration/PromSettings.tsx
+++ b/src/configuration/PromSettings.tsx
@@ -128,7 +128,7 @@ export const PromSettings = (props: Props) => {
             <FormField
               label="Custom query parameters"
               labelWidth={14}
-              tooltip="Add Custom parameters to all Prometheus or Thanos queries."
+              tooltip="Add Custom parameters to all queries."
               inputEl={
                 <Input
                   className="width-25"


### PR DESCRIPTION
This PR addresses a bug that prevented custom query parameters from being properly processed in annotation queries. 
- #95