### PR TITLE
deployment: add windows build for backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* FEATURE: add support for the windows OS. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/67).  
+* FEATURE: add Windows support for backend plugin. See how to build backend plugin for various platforms [here](https://github.com/VictoriaMetrics/grafana-datasource#3-how-to-build-backend-plugin). See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/67).  
 * FEATURE: the annotation editor component has been migrated from using Angular template to React. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/102).
 
 ## [v0.4.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* FEATURE: add support for the windows OS. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/67).  
 * FEATURE: the annotation editor component has been migrated from using Angular template to React. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/102).
 
 ## [v0.4.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.4.0)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ app-via-docker-darwin-arm64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(MAKE) app-via-docker-goos-goarch
 
 app-via-docker-windows-amd64:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(MAKE) app-via-docker-windows
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(MAKE) app-via-docker-windows-goarch
 
 victoriametrics-backend-plugin-build: \
 	victoriametrics-backend-plugin-linux-amd64-prod \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ app-via-docker-goos-goarch:
 	DOCKER_OPTS='--env CGO_ENABLED=$(CGO_ENABLED) --env GOOS=$(GOOS) --env GOARCH=$(GOARCH)' \
 	$(MAKE) app-via-docker
 
+app-via-docker-windows-goarch:
+	APP_SUFFIX='_$(GOOS)_$(GOARCH)' \
+	DOCKER_OPTS='--env CGO_ENABLED=$(CGO_ENABLED) --env GOOS=$(GOOS) --env GOARCH=$(GOARCH)' \
+	$(MAKE) app-via-docker-windows
+
 app-via-docker-linux-amd64:
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-via-docker-goos-goarch
 
@@ -48,13 +53,17 @@ app-via-docker-darwin-amd64:
 app-via-docker-darwin-arm64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(MAKE) app-via-docker-goos-goarch
 
+app-via-docker-windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(MAKE) app-via-docker-windows
+
 victoriametrics-backend-plugin-build: \
 	victoriametrics-backend-plugin-linux-amd64-prod \
 	victoriametrics-backend-plugin-linux-arm-prod \
 	victoriametrics-backend-plugin-linux-arm64-prod \
 	victoriametrics-backend-plugin-linux-386-prod \
 	victoriametrics-backend-plugin-amd64-prod \
-	victoriametrics-backend-plugin-arm64-prod
+	victoriametrics-backend-plugin-arm64-prod \
+	victoriametrics-backend-plugin-windows-prod
 
 victorimetrics-frontend-plugin-build: \
 	frontend-build

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ This command will build executable multi-platform files to the `dist` folder for
 * linux/386
 * amd64
 * arm64
+* windows
 
 ### 4.How to build frontend plugin
 From the root folder of the project run the following command:

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -38,6 +38,20 @@ app-via-docker: package-builder
 			-tags 'netgo osusergo nethttpomithttp2 musl' \
 			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX) ./pkg/
 
+app-via-docker-windows: package-builder
+	mkdir -p gocache-for-docker
+	docker run --rm \
+		-v "$(shell pwd):/usr/local/go/src/victoriametrics-datasource" \
+        -w /usr/local/go/src/victoriametrics-datasource \
+        -v "$(shell pwd)/gocache-for-docker:/gocache" \
+        --env GOCACHE=/gocache \
+		$(DOCKER_OPTS) \
+		$(BUILDER_IMAGE) \
+		go build $(RACE) -trimpath -buildvcs=false \
+			-ldflags "-s -w -extldflags '-static' $(GO_BUILDINFO)" \
+			-tags 'netgo osusergo nethttpomithttp2' \
+			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX) ./pkg/
+
 frontend-package-base-image:
 	docker build -t frontent-builder-image -f deployment/docker/web/Dockerfile ./deployment/docker/web
 

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -50,7 +50,7 @@ app-via-docker-windows: package-builder
 		go build $(RACE) -trimpath -buildvcs=false \
 			-ldflags "-s -w -extldflags '-static' $(GO_BUILDINFO)" \
 			-tags 'netgo osusergo nethttpomithttp2' \
-			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX) ./pkg/
+			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX).exe ./pkg/
 
 frontend-package-base-image:
 	docker build -t frontent-builder-image -f deployment/docker/web/Dockerfile ./deployment/docker/web

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -18,3 +18,6 @@ victoriametrics-backend-plugin-amd64-prod:
 
 victoriametrics-backend-plugin-arm64-prod:
 	APP_NAME=victoriametrics_backend_plugin $(MAKE) app-via-docker-darwin-arm64
+
+victoriametrics-backend-plugin-windows-prod:
+	APP_NAME=victoriametrics_backend_plugin $(MAKE) app-via-docker-windows-amd64


### PR DESCRIPTION
Enabled Windows build for backend plugin.

Related issue: https://github.com/VictoriaMetrics/grafana-datasource/issues/67

Signed-off-by: dmitryk-dk [d.kozlov@victoriametrics.com](mailto:d.kozlov@victoriametrics.com)