### PR TITLE
ci: setup copying readme as documentation page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,78 @@
+name: Update docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/docs.yaml"
+      - "README.md"
+      - "docs/**"
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    environment:
+      name: docs
+      url: https://docs.victoriametrics.com/
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          repository: VictoriaMetrics/grafana-datasource
+          ref: main
+          token: ${{ secrets.VM_BOT_GH_TOKEN }}
+          path: "__vm-datasource-repo"
+
+      - name: Check out VM code
+        uses: actions/checkout@v4
+        with:
+          repository: VictoriaMetrics/VictoriaMetrics
+          ref: master
+          token: ${{ secrets.VM_BOT_GH_TOKEN }}
+          path: "__vm-docs-repo"
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.VM_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.VM_BOT_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          workdir: "__vm-docs-repo"
+
+      # Copies README.md and assets from docs/assets
+      - name: Update ds docs in VM repo
+        run: |
+          echo '
+          ---
+          sort: 38
+          weight: 38
+          title: Grafana datasource
+          menu:
+            docs:
+              parent: 'victoriametrics'
+              weight: 38
+          aliases:
+          - /grafana-datasource.html"
+          ---
+          ' > docs.md > ../__vm-docs-repo/docs/grafana-datasource.md
+
+          cat ./README.md >>  ../__vm-docs-repo/docs/grafana-datasource.md
+          sed -i 's|docs/assets/||g' ../__vm-docs-repo/docs/grafana-datasource.md
+          
+          cp docs/assets/* ../__vm-docs-repo/docs/
+        working-directory: "__vm-datasource-repo"
+
+      - name: Commit and push changes
+        run: |
+          export VM_GIT_BRANCH_NAME="ds-docs-update-$(date +%s)"
+          export VM_GIT_COMMIT_SHA="$(git rev-parse --short $GITHUB_SHA)"
+          git checkout -b "${VM_GIT_BRANCH_NAME}"
+          git add docs/
+          git commit -S -m "Automatic update Grafana datasource docs from ${GITHUB_REPOSITORY}@${VM_GIT_COMMIT_SHA}"
+          git push origin ${VM_GIT_BRANCH_NAME}
+          gh pr create -f
+        working-directory: "__vm-docs-repo"
+        env:
+          GITHUB_TOKEN: ${{ secrets.VM_BOT_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -375,4 +375,4 @@ or Loki type. See more details [here](https://github.com/VictoriaMetrics/grafana
 
 ## License
 
-This project is licensed under the [AGPL-3.0-only](LICENSE).
+This project is licensed under the [AGPL-3.0-only](https://github.com/VictoriaMetrics/grafana-datasource/blob/main/LICENSE).


### PR DESCRIPTION
Copies README.md file as a separate documentation page of main docs.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/5299