### PR TITLE
fix the default link to vmui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix the default link to vmui. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/132)
+
 ## [v0.5.1](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.5.1)
 
 * BUGFIX: fix query builder logic to correctly parse metric names with dots. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/128)

--- a/src/components/VmuiLink.tsx
+++ b/src/components/VmuiLink.tsx
@@ -32,7 +32,7 @@ interface Props {
   dashboardUID: string;
 }
 
-export const getDefaultVmuiUrl = (serverUrl: string) => `${serverUrl.replace(/\/$/, "")}/vmui/`
+export const getDefaultVmuiUrl = (serverUrl = "#") => `${serverUrl.replace(/\/$/, "")}/vmui/`
 
 export const relativeTimeOptionsVMUI = [
   { title: "Last 5 minutes", duration: "5m" },

--- a/src/components/VmuiLink.tsx
+++ b/src/components/VmuiLink.tsx
@@ -32,6 +32,8 @@ interface Props {
   dashboardUID: string;
 }
 
+export const getDefaultVmuiUrl = (serverUrl: string) => `${serverUrl.replace(/\/$/, "")}/vmui/`
+
 export const relativeTimeOptionsVMUI = [
   { title: "Last 5 minutes", duration: "5m" },
   { title: "Last 15 minutes", duration: "15m" },
@@ -124,7 +126,7 @@ const VmuiLink: FC<Props> = ({
         return k + '=' + encodeURIComponent(v);
       }).join('&');
 
-      const vmuiUrl = dsSettings.jsonData.vmuiUrl || `${dsSettings.url}/graph`
+      const vmuiUrl = dsSettings.jsonData.vmuiUrl || getDefaultVmuiUrl(dsSettings.url)
       setHref(`${vmuiUrl}?${args}`);
     };
 

--- a/src/configuration/PromSettings.tsx
+++ b/src/configuration/PromSettings.tsx
@@ -33,6 +33,7 @@ import {
   regexValidation,
 } from '@grafana/ui';
 
+import { getDefaultVmuiUrl } from "../components/VmuiLink";
 import { PromOptions } from '../types';
 
 const { Input, FormField } = LegacyForms;
@@ -154,7 +155,7 @@ export const PromSettings = (props: Props) => {
                   value={options.jsonData.vmuiUrl}
                   onChange={onChangeHandler('vmuiUrl', options, onOptionsChange)}
                   spellCheck={false}
-                  placeholder={`${options.url}/graph?`}
+                  placeholder={getDefaultVmuiUrl(options.url)}
                 />
               }
             />

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -56,6 +56,7 @@ import {
 
 import { addLabelToQuery } from './add_label_to_query';
 import { AnnotationQueryEditor } from "./components/Annotations/AnnotationQueryEditor";
+import { getDefaultVmuiUrl } from "./components/VmuiLink";
 import { WithTemplate } from "./components/WithTemplateConfig/types";
 import { mergeTemplateWithQuery } from "./components/WithTemplateConfig/utils/getArrayFromTemplate";
 import { ANNOTATION_QUERY_STEP_DEFAULT, DATASOURCE_TYPE } from "./consts";
@@ -134,7 +135,7 @@ export class PrometheusDatasource
     this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
     this.directUrl = instanceSettings.jsonData.directUrl ?? this.url;
-    this.vmuiUrl = instanceSettings.jsonData.vmuiUrl || `${this.url}/graph`;
+    this.vmuiUrl = instanceSettings.jsonData.vmuiUrl || getDefaultVmuiUrl(this.url);
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
     this.ruleMappings = {};
     this.languageProvider = languageProvider ?? new PrometheusLanguageProvider(this);


### PR DESCRIPTION
- A feature has been added to generate a default link for vmui.
- The default vmui link has been changed from `/graph` to `/vmui/`.
- Fixed #132