### PR TITLE
fix logic for replacing legend label names 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [v0.5.1](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.5.1)
 
 * BUGFIX: fix query builder logic to correctly parse metric names with dots. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/128)
+* BUGFIX: fix the parsing logic in `renderLegendFormat` to correctly replace legend label names. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/133)
 
 ## [v0.5.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.5.0)
 

--- a/src/legend.test.ts
+++ b/src/legend.test.ts
@@ -25,6 +25,6 @@ describe('renderLegendFormat()', () => {
     expect(renderLegendFormat('value: {a}}}', labels)).toEqual('value: {a}}}');
 
     // Current behavior -- not sure if expected or not
-    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {a}');
+    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {AAA}');
   });
 });

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -17,6 +17,6 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
-  return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
+  const aliasRegex = /\{\{\s*([^{}]+?)\s*}}/g
+  return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] || ""));
 }


### PR DESCRIPTION
- Updated the regular expression in the `renderLegendFormat` function for more precise matching.
- Modified the default value in `renderLegendFormat` to return an empty string for undefined labels.
- Revised the test case for `renderLegendFormat` to align with the updated function logic.
- Addressing issue #133 