### PR TITLE
fix the queries for `Label Filters` and `Metrics Browser` for metrics with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: correct the queries for `Label Filters` and `Metrics Browser` for metrics with special characters. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/140)
+
 ## [v0.6.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.6.0)
 
 * FEATURE: add support metrics with special characters in query builder. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/131)

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -61,7 +61,11 @@ import { WithTemplate } from "./components/WithTemplateConfig/types";
 import { mergeTemplateWithQuery } from "./components/WithTemplateConfig/utils/getArrayFromTemplate";
 import { ANNOTATION_QUERY_STEP_DEFAULT, DATASOURCE_TYPE } from "./consts";
 import PrometheusLanguageProvider from './language_provider';
-import { expandRecordingRules } from './language_utils';
+import {
+  escapeMetricNameSpecialCharacters,
+  expandRecordingRules,
+  unescapeMetricNameSpecialCharacters
+} from './language_utils';
 import { renderLegendFormat } from './legend';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { getInitHints, getQueryHints } from './query_hints';
@@ -1019,7 +1023,10 @@ export class PrometheusDatasource
   }
 
   interpolateString(string: string) {
-    return this.templateSrv.replace(string, undefined, this.interpolateQueryExpr);
+    const operation = string.includes("__name__")
+      ? unescapeMetricNameSpecialCharacters
+      : escapeMetricNameSpecialCharacters;
+    return this.templateSrv.replace(operation(string), undefined, this.interpolateQueryExpr);
   }
 
   withTemplatesUpdate(withTemplates: WithTemplate[]) {

--- a/src/language_utils.ts
+++ b/src/language_utils.ts
@@ -287,6 +287,11 @@ export function escapeMetricNameSpecialCharacters(metricName: string) {
   return metricName.replace(specialChars, (match) => '\\' + match);
 }
 
+export function unescapeMetricNameSpecialCharacters(escapedMetricName: string) {
+  const escapedSpecialChars = /\\([-+*\/%^=])/g;
+  return escapedMetricName.replace(escapedSpecialChars, (match, p1) => p1);
+}
+
 export enum AbstractLabelOperator {
   Equal = "Equal",
   NotEqual = "NotEqual",


### PR DESCRIPTION
The pull request fixes escaping in metric names with special characters in requests for obtaining `label=values`.

Ref: #140 and https://github.com/VictoriaMetrics/grafana-datasource/issues/131#issuecomment-1919127947