### PR TITLE
feat: add visually highlight partial responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## tip
+* FEATURE: add visually highlight partial responses. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/142)
 
 * BUGFIX: correct the queries for `Label Filters` and `Metrics Browser` for metrics with special characters. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/140)
 

--- a/src/result_transformer.ts
+++ b/src/result_transformer.ts
@@ -34,6 +34,7 @@ import {
   Labels,
   MutableField,
   PreferredVisualisationType,
+  QueryResultMetaNotice,
   ScopedVars,
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
@@ -260,6 +261,17 @@ export function transform(
   };
   const prometheusResult = response.data.data;
   const traceResult = response.data?.trace
+
+  if (response.data.isPartial) {
+    const partialWarning = {
+      severity: "warning",
+      text: `The shown results are marked as PARTIAL. The result is marked as partial if one or more vmstorage nodes failed to respond to the query.`
+    } as QueryResultMetaNotice
+
+    Array.isArray(options.meta.notices)
+      ? options.meta.notices.push(partialWarning)
+      : options.meta.notices = [partialWarning]
+  }
 
   if (isExemplarData(prometheusResult)) {
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface PromDataSuccessResponse<T = PromData> {
   status: 'success';
   data: T;
   trace?: TracingData;
+  isPartial?: boolean;
 }
 
 export interface PromDataErrorResponse<T = PromData> {


### PR DESCRIPTION
The pull request adds the display of a warning for responses with an additional field in the JSON response `"isPartial": true`. 

FYI: Grafana is responsible for the visualization. From our side, we pass the metadata: type and message.

#142

<img width="600" alt="Screenshot 2024-02-19 at 15 06 43" src="https://github.com/VictoriaMetrics/grafana-datasource/assets/29711459/52762346-cfaf-4657-a950-c624c03006a5">

<img width="600" alt="Screenshot 2024-02-19 at 15 06 28" src="https://github.com/VictoriaMetrics/grafana-datasource/assets/29711459/cc975229-8d04-4a39-8d1c-75287b3883cd">