### PR TITLE
Fix annotations templating (#146)

### DIFF
--- a/src/components/Annotations/AnnotationQueryEditor.tsx
+++ b/src/components/Annotations/AnnotationQueryEditor.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { AnnotationQuery } from '@grafana/data';
 import { AutoSizeInput, LegacyForms } from '@grafana/ui';
 
+
 const { Input } = LegacyForms;
 import { PromQueryCodeEditor } from '../../querybuilder/components/PromQueryCodeEditor';
 import { PromQuery } from '../../types';

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 import { cloneDeep, defaults } from 'lodash';
 import { forkJoin, lastValueFrom, merge, Observable, of, OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, filter, map, tap } from 'rxjs/operators';
@@ -388,7 +389,7 @@ export class PrometheusDatasource
 
 
       if (request.targets.every(t => t.refId === "Anno")) {
-        const query = request.targets[0] as PromQueryRequest
+        const query = { ...request.targets[0], expr: queries[0].expr } as PromQueryRequest
         return this.performAnnotationQuery({ ...query, start, end })
       }
 
@@ -714,6 +715,7 @@ export class PrometheusDatasource
   };
 
   performAnnotationQuery = (query: PromQueryRequest) => {
+    const correctQuery = { ...query, datasource: { uid: this.templateSrv.replace(query.datasource!.uid, {}), type: query.datasource!.type } };
     return getBackendSrv()
       .fetch<BackendDataSourceResponse>({
         url: '/api/ds/query',
@@ -721,7 +723,7 @@ export class PrometheusDatasource
         data: {
           from: (query.start * 1000).toString(),
           to: (query.end * 1000).toString(),
-          queries: [{ ...query, refId: "X" }],
+          queries: [{ ...correctQuery, refId: "X" }],
         },
         requestId: query.requestId,
       }).pipe(


### PR DESCRIPTION
It is an implemented changes I presented on #146 , with small change - the datasource.uid has to be only changed for the query. Doing it otherwise, it will change the datasource on UI making it impossible to use variable in there.

Original prometheus code uses `this.uid` everywhere but this value is updated only after request to DS was done already. The codebaseses of these plugins are similar but I believe some changes were made in recent Grafana code.