### PR TITLE
Fix template variable service errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue in the template variable service where accessing the `datasource` property of `undefined` caused a failure. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/150).
+
 ## [v0.8.0](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.8.0)
 
 * FEATURE: add variable type selector to optimize API usage, favoring [/api/v1/labels](https://docs.victoriametrics.com/url-examples/#apiv1labels) and [/api/v1/label/.../values](https://docs.victoriametrics.com/url-examples/#apiv1labelvalues) over [/api/v1/series](https://docs.victoriametrics.com/url-examples/#apiv1series). See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/144)

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -42,7 +42,7 @@ export class PrometheusVariableSupport extends CustomVariableSupport<PrometheusD
 
   editor = VariableQueryEditor;
 
-  query(request: DataQueryRequest<PromVariableQuery>): Observable<DataQueryResponse> {
+  query = (request: DataQueryRequest<PromVariableQuery>): Observable<DataQueryResponse> => {
     // Handling grafana as code from jsonnet variable queries which are strings and not objects
     // Previously, when using StandardVariableSupport
     // the variable query string was changed to be on the expr attribute


### PR DESCRIPTION
This pull request addresses the issue where the this context was lost in the template variable service, leading to errors when processing template variables. 
By converting the function to an arrow function, we ensure the this scope is preserved.

#150