### PR TITLE
Update unpacking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please find the example of provisioning Grafana instance with VictoriaMetrics da
    ``` bash
    ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/grafana-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
    curl -L https://github.com/VictoriaMetrics/grafana-datasource/releases/download/$ver/victoriametrics-datasource-$ver.tar.gz -o plugin.tar.gz
-   tar -xf plugin.tar.gz -C ./victoriametrics-datasource
+   tar -xf plugin.tar.gz -C ./
    rm plugin.tar.gz
    ```
 


### PR DESCRIPTION
I get the following error while following the instructions:
```sh
 $ tar -xf plugin.tar.gz -C ./victoriametrics-datasource
tar: victoriametrics-datasource: Cannot open: No such file or directory
```
Also I noticed the package already contains everything within `victoriametrics-datasource` directory inside the archive, so unpacking into current directory seems like a right thing.