### PR TITLE
Fix parsing of label names with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix parsing of label names with special characters for the query builder. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/131#issuecomment-2105662179).
+
 ## [v0.8.1](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.8.1)
 
 * BUGFIX: fix an issue in the template variable service where accessing the `datasource` property of `undefined` caused a failure. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/150).

--- a/packages/lezer-metricsql/package.json
+++ b/packages/lezer-metricsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lezer-metricsql",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "index.cjs",
   "type": "module",
   "exports": {

--- a/packages/lezer-metricsql/src/metricsql.grammar
+++ b/packages/lezer-metricsql/src/metricsql.grammar
@@ -398,7 +398,7 @@ NumberLiteral  {
   EscapedChar {("\\" AnyEscapesChar) ("\\" AnyEscapesChar)*}
   AnyEscapesChar { "-" | "+" | "*" | "/" | "%" | "^" | "=" }
   Identifier {(std.asciiLetter | "_" | ":" | "." | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)*}
-  LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
+  LabelName {(std.asciiLetter | "_" | ":" | "." | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)*}
 
   // Operator
   Sub { "-" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,7 +6841,7 @@ levn@^0.4.1:
     type-check "~0.4.0"
 
 "lezer-metricsql@file:packages/lezer-metricsql":
-  version "0.1.2"
+  version "0.1.3"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"


### PR DESCRIPTION
fix parsing of label names with special characters for the query builder

[ #131](https://github.com/VictoriaMetrics/grafana-datasource/issues/131#issuecomment-210566217)