### PR TITLE
follow up after 1b06a341fb22ad5652a258d77b577508bad70216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix an issue with prettify query if the query includes Grafana variables in the lookbehind window. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/166).
+* BUGFIX: fix an issue with ad-hoc filters applied to variables in query. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/167). 
 
 ## [v0.8.2](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.8.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## tip
 
 * BUGFIX: fix an issue with prettify query if the query includes Grafana variables in the lookbehind window. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/166).
-* BUGFIX: fix an issue with ad-hoc filters applied to variables in query. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/167). 
+* BUGFIX: fix an issue with ad-hoc filters applied to variables in query. See [this issue](https://github.com/VictoriaMetrics/grafana-datasource/issues/167). Thanks to @yincongcyincong for [the pull request](https://github.com/VictoriaMetrics/grafana-datasource/pull/170).
 
 ## [v0.8.2](https://github.com/VictoriaMetrics/grafana-datasource/releases/tag/v0.8.2)
 


### PR DESCRIPTION
Added changelog for fix https://github.com/VictoriaMetrics/grafana-datasource/pull/170

I have checked the possibility of moving logic from prettify query to the data source, which we discussed [here](https://github.com/VictoriaMetrics/grafana-datasource/pull/169#issuecomment-2182473349)

I think it is not a good idea to move logic by removing logic from the prettify component to another place because those changes only relate to the prettify functionality.

But I need another opinion about my thoughts