### PR TITLE
fix: set a default format to time_series for queries without an explicit format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix the issue with dashboards showing no data when the `format` field was undefined. Now the `format` defaults to `time_series` when not explicitly set, ensuring proper data visualization for existing queries and dashboards. See [#377](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/377)
+
 ## v0.19.1
 
 * BUGFIX: fix duplication of statistics panels. See [#372](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/372)

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -687,6 +687,43 @@ describe('PrometheusDatasource for POST', () => {
       expect(results.data.length).toBe(1);
       expect(results.data[0].meta.preferredVisualisationType).toStrictEqual('graph');
     });
+
+
+    it('with instant: false and range:true without format should return 1 visualizations - graph', async () => {
+      const query = {
+        range: { from: time({ minutes: 1, seconds: 3 }), to: time({ minutes: 2, seconds: 3 }) },
+        targets: [{ expr: 'test{job="testjob"}', format: undefined, refId: 'A', instant: false, range: true }],
+        interval: '60s',
+      } as DataQueryRequest<PromQuery>;
+
+      const response = {
+        status: 200,
+        data: {
+          resultType: 'matrix',
+          results: {
+            A: {
+              series: [
+                {
+                  refId: 'A',
+                  tags: { __name__: 'test', job: 'testjob' },
+                  points: [[2 * 60, '3846']],
+                },
+              ],
+            },
+          },
+        },
+      };
+      fetchMock.mockImplementation(() => of(response));
+      await new Promise((resolve) => {
+        ds.query(query).subscribe((data) => {
+          results = data;
+          resolve('');
+        });
+      });
+
+      expect(results.data.length).toBe(1);
+      expect(results.data[0].meta.preferredVisualisationType).toStrictEqual('graph');
+    });
   });
 
   describe('When querying prometheus with one target using query editor target spec - table format', () => {


### PR DESCRIPTION
Related issue: #377 
The bug was introduced in #372 
Fixed issue with dashboards showing no data when format field was undefined.
Now format defaults to 'time_series' when not explicitly set, ensuring
proper data visualization for existing queries and dashboards.
Tested on playground dashboards.
<img width="2389" height="1303" alt="image" src="https://github.com/user-attachments/assets/8e68da74-37c2-4871-91d6-27e51e8dfaa6" />


