### PR TITLE
fix applying `Custom query parameters` when querying from Grafana variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix applying `WITH` template to the query expression. See [#397](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/397).
+* BUGFIX: fix applying `Custom query parameters` when querying from Grafana variables. See [#396](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/396).
 
 ## v0.19.4
 

--- a/src/components/WithTemplateConfig/hooks/useValidateExpr.ts
+++ b/src/components/WithTemplateConfig/hooks/useValidateExpr.ts
@@ -38,7 +38,7 @@ const validateStatus: {[key: string]: ValidateResult} = {
   }
 }
 
-export default (datasourceUID: number) => {
+export default (datasourceUID: string) => {
   const [validateResult, setValidateResult] = useState<ValidateResult>(validateStatus.noValidate)
 
   const isValidExpr = useCallback(async (expr: string) => {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -76,6 +76,7 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
       expect(fetchMock.mock.calls[0][0].params).toEqual({ bar: 'baz baz', foo: 'foo' });
     });
+
     it('should still perform a GET request with the DS HTTP method set to POST and not POST-friendly endpoint', () => {
       const postSettings = cloneDeep(instanceSettings);
       postSettings.jsonData.httpMethod = 'POST';
@@ -84,6 +85,7 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls.length).toBe(1);
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });
+
     it('should try to perform a GET request with the DS HTTP method set to GET and GET-friendly endpoint', () => {
       const postSettings = cloneDeep(instanceSettings);
       const promDs = new PrometheusDatasource(postSettings, templateSrvStub, timeSrvStub);
@@ -92,6 +94,22 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
       expect(fetchMock.mock.calls[0][0].url).not.toContain('bar=baz%20baz&foo=foo');
       expect(fetchMock.mock.calls[0][0].params).toEqual({ bar: 'baz baz', foo: 'foo' });
+    });
+
+    it('should perform a GET request with the custom query params', () => {
+      const postSettings = cloneDeep(instanceSettings);
+      const promDs = new PrometheusDatasource({
+        ...postSettings,
+        jsonData: { customQueryParameters: "extra_filter[]={foo: \"bar\"}" }
+      }, templateSrvStub, timeSrvStub);
+      promDs.getRequest('api/v1/label/id/values', { bar: 'baz baz', foo: 'foo' });
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+      expect(fetchMock.mock.calls[0][0].params).toEqual({
+        bar: 'baz baz',
+        foo: 'foo',
+        "extra_filter[]": "{foo: \"bar\"}",
+      });
     });
   });
 

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -81,6 +81,7 @@ export class PrometheusDatasource
   languageProvider: PrometheusLanguageProvider;
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
   lookupsDisabled: boolean;
+  customQueryParameters: any;
   exemplarsAvailable: boolean;
   subType: PromApplication;
   rulerEnabled: boolean;
@@ -111,6 +112,7 @@ export class PrometheusDatasource
     this.ruleMappings = {};
     this.languageProvider = languageProvider ?? new PrometheusLanguageProvider(this);
     this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup ?? false;
+    this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
     this.variables = new PrometheusVariableSupport(this, this.templateSrv);
     this.exemplarsAvailable = false;
     this.withTemplates = instanceSettings.jsonData.withTemplates ?? [];
@@ -139,7 +141,12 @@ export class PrometheusDatasource
   }
 
   // Use this for tab completion features, won't publish response to other components
-  async getRequest(url: string, params = {}, options?: Partial<BackendSrvRequest>) {
+  async getRequest(url: string, params: BackendSrvRequest["params"] = {}, options?: Partial<BackendSrvRequest>) {
+    for (const [key, value] of this.customQueryParameters) {
+      if (params[key] === undefined) {
+        params[key] = value;
+      }
+    }
     return await this.getResource(url, params, {
       hideFromInspector: true,
       showErrorAlert: false,
@@ -584,6 +591,10 @@ export class PrometheusDatasource
       start: getVictoriaMetricsTime(timeRange.from, false).toString(),
       end: getVictoriaMetricsTime(timeRange.to, true).toString(),
     };
+  }
+
+  getTemplateSrv() {
+    return this.templateSrv;
   }
 }
 

--- a/src/metric_find_query.test.ts
+++ b/src/metric_find_query.test.ts
@@ -1,19 +1,19 @@
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { DataSourceInstanceSettings, TimeRange, toUtc } from '@grafana/data';
-import { BackendDataSourceResponse, BackendSrvRequest, FetchResponse, TemplateSrv, getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { BackendSrvRequest, FetchResponse, TemplateSrv, getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
 import { PrometheusDatasource } from './datasource';
 import PrometheusMetricFindQuery from "./metric_find_query";
 import { PromOptions } from "./types";
 
-const fetchMock = jest.fn((_options: BackendSrvRequest): Observable<FetchResponse<BackendDataSourceResponse>> => {
+const fetchMock = jest.fn((_options: BackendSrvRequest) => {
   return of({} as unknown as FetchResponse);
 });
 
 setBackendSrv({
   ...getBackendSrv(),
-  fetch: fetchMock,
+  fetch: fetchMock ,
 });
 
 const instanceSettings = {


### PR DESCRIPTION
Related issue: #396 
1. Added custom query parameters to requests.
2. Fixed few typecheck errors.