### PR TITLE
fix an issue where the `Prettify query` action caused the refId to be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where the `Prettify query` action caused the refId to be deleted. See [#397](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/397).
+
 ## v0.19.5
 
 * BUGFIX: fix applying `WITH` template to the query expression. See [#397](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/397).

--- a/src/components/PrettifyQuery.tsx
+++ b/src/components/PrettifyQuery.tsx
@@ -60,10 +60,8 @@ const PrettifyQuery: FC<Props> = ({
       });
 
       const response = await datasource.getRequest('prettify-query', { query: expr }, {});
-      const { status, query } = response;
-
-      if (status === ResponseStatus.Success && query) {
-        let prettifiedQuery = query;
+      if (response.status === ResponseStatus.Success && response.query) {
+        let prettifiedQuery = response.query;
 
         // Replace temporary values with grafana variables
         GRAFANA_VARIABLES.forEach((variable) => {
@@ -75,7 +73,7 @@ const PrettifyQuery: FC<Props> = ({
 
         onChange({ ...query, expr: prettifiedQuery });
       } else {
-        console.error(`Error prettifying query: ${status || 'Unknown error'}`);
+        console.error(`Error prettifying query: ${response.status || 'Unknown error'}`);
       }
     } catch (e) {
       console.error('Error prettifying query:', e);


### PR DESCRIPTION
Related issue: #404 

Fixed an issue where the `Prettify query` action caused the refId to be deleted. The problem was that the destructuring of the response to the query overwritten query from the props.