### PR TITLE
fix an issue where `Min step` > `Min interval` causes an empty graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where `Min step` > `Min interval` causes an empty graph. See [#377](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/377).
+
 ## v0.19.6
 
 * BUGFIX: fix an issue where the `Prettify query` action caused the refId to be deleted. See [#397](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/397).

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -56,6 +56,7 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 	}
 
 	step := q.calculateStep(minInterval)
+	q.IntervalMs = step.Milliseconds()
 	expr := replaceTemplateVariable(q.Expr, q.BackendQueryInterval, step, originalQueryInterval, q.TimeInterval, timerange)
 
 	if expr == "" {


### PR DESCRIPTION
Related issue: #377 
Fixed an issue where `Min step` > `Min interval` causes an empty graph