### PR TITLE
add FreeBSD (amd64) build target for datasource backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: merge metadata with all available metrics in the query builder. This ensures users can see all available metrics in the metrics explorer, with proper type information when available, while still being able to select metrics that don't yet have metadata defined. See [#442](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/442).
 
+* BUGFIX: add FreeBSD (amd64) build target for datasource backend. See [#446](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/446).
+
 ## v0.21.0
 
 * FEATURE: add metrics metadata exploration to the query builder. The button with the book-open icon opens the metrics explorer modal, where the user can explore the metrics metadata. See [#417](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/417).

--- a/Magefile.go
+++ b/Magefile.go
@@ -4,25 +4,28 @@
 package main
 
 import (
-        // mage:import
-        "github.com/grafana/grafana-plugin-sdk-go/build"
-        "github.com/magefile/mage/mg"
+	// mage:import
+	"github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/magefile/mage/mg"
 )
 
 func init() {
-        build.SetBeforeBuildCallback(func(cfg build.Config) (build.Config, error) {
-                // Do something before building
-                cfg.OutputBinaryPath = "plugins/victoriametrics-metrics-datasource"
-                return cfg, nil
-        })
+	build.SetBeforeBuildCallback(func(cfg build.Config) (build.Config, error) {
+		// Do something before building
+		cfg.OutputBinaryPath = "plugins/victoriametrics-metrics-datasource"
+		return cfg, nil
+	})
 }
 
 func Build() {
-        b := build.Build{}
-        linuxS390 := func () error {
-                return b.Custom("linux", "s390x")
-        }
-        mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, linuxS390)
+	b := build.Build{}
+	linuxS390 := func() error {
+		return b.Custom("linux", "s390x")
+	}
+	freebsd := func() error {
+		return b.Custom("freebsd", "amd64")
+	}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, linuxS390, freebsd)
 }
 
 // Default configures the default target.


### PR DESCRIPTION
Related issue: #446 

### Describe Your Changes

Added FreeBSD (amd64) build target for the datasource backend

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a FreeBSD (amd64) build target to the Grafana datasource backend so the plugin builds and runs on FreeBSD. Fixes #446.

- **Bug Fixes**
  - Add freebsd/amd64 target to Magefile.go and include it in the default build.
  - Update CHANGELOG.

<sup>Written for commit dda60460645b1184de9c5811fda6cc23ae8ce25a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

