### PR TITLE
update workflow to use pull_request_target event and remove unused variable

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,7 +1,7 @@
 name: PR Merge - Update Related Issues with the 'waiting for release' label and comment
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:
@@ -19,7 +19,6 @@ jobs:
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
-            const prNumber = context.payload.pull_request.number;
             
             let issueNumbers = new Set();
             


### PR DESCRIPTION
### Describe Your Changes

Problem: Currently, when we merge the external PR, the merge action has no access to the GITHUB_TOKEN to update the related issue.
Solution: Use the `pull_request_target` to grant access. But it is still secure because we don't execute or checkout the code from the PR; we just update the issue with a label and a comment.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the PR merge workflow to use pull_request_target so the action has GITHUB_TOKEN when external PRs are merged and can label/comment on related issues. Kept it safe by not checking out PR code; also removed an unused variable.

<sup>Written for commit 417c28240df74ee9939b877cedd105f3c0572e95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

