### PR TITLE
fix brace-expansion vulnerability via resolutions (#GHSA-f886-m6hf-6m8v)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "picomatch@^4.0.3": "4.0.4",
     "brace-expansion@^1.1.7": "1.1.13",
     "brace-expansion@^5.0.2": "5.0.5",
-    "serialize-javascript": ">=7.0.3",
+    "serialize-javascript": ">=7.0.5",
     "yaml": "1.10.3"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12896,10 +12896,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:>=7.0.3":
-  version: 7.0.4
-  resolution: "serialize-javascript@npm:7.0.4"
-  checksum: 10c0/f3da6f994c41306fbfabb55eefe280a46da05592939a84b0d95c84e296c92ba9e6a3d86cf7bbd71e7a59e1cfcd8481745910af109bedbd3ed853b444d32f9ee9
+"serialize-javascript@npm:>=7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

Fix brace-expansion vulnerability via resolutions (#GHSA-f886-m6hf-6m8v)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `brace-expansion` vulnerability (GHSA-f886-m6hf-6m8v) via Yarn resolutions. Pins `brace-expansion` to 1.1.13/5.0.5 and bumps `serialize-javascript` to 7.0.5; no runtime code changes.

<sup>Written for commit 5d686347f60cf8f391b3dc64371cfd10296cedf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

