### PR TITLE
fix: autocomplete inserts duplicate prefix for dotted metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix autocomplete inserting duplicate prefix for metric names containing dots (e.g. `kubernetes.pod.id`). See [#493](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/493).
+
 * MAINTENANCE: update Grafana dependency range to support version 13.x.x.
 
 ## v0.23.3

--- a/src/components/monaco-query-field/monaco-completion-provider/getDottedIdentifierBounds.test.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/getDottedIdentifierBounds.test.ts
@@ -1,0 +1,56 @@
+import { getDottedIdentifierBounds } from './getDottedIdentifierBounds';
+
+describe('getDottedIdentifierBounds', () => {
+  it('should cover the full dotted metric name when cursor is at the end', () => {
+    // "kubernetes.pod" with cursor at end (col 14, 0-based)
+    const { start, end } = getDottedIdentifierBounds('kubernetes.pod', 14);
+    expect(start).toBe(0);
+    expect(end).toBe(14);
+  });
+
+  it('should cover the full dotted metric name when cursor is in the middle', () => {
+    //                              cursor here ──┐
+    // "kubernetes.pod.id"  indices: 0123456789...14..16
+    const { start, end } = getDottedIdentifierBounds('kubernetes.pod.id', 14);
+    expect(start).toBe(0);
+    expect(end).toBe(17); // "kubernetes.pod.id".length === 17
+  });
+
+  it('should handle simple metric name without dots', () => {
+    const { start, end } = getDottedIdentifierBounds('metric_name', 6);
+    expect(start).toBe(0);
+    expect(end).toBe(11);
+  });
+
+  it('should handle cursor at the beginning of a dotted name', () => {
+    const { start, end } = getDottedIdentifierBounds('kubernetes.pod.id', 0);
+    expect(start).toBe(0);
+    expect(end).toBe(17);
+  });
+
+  it('should handle metric name after other text', () => {
+    // "rate(kubernetes.pod.id" with cursor at end (col 22, 0-based)
+    const { start, end } = getDottedIdentifierBounds('rate(kubernetes.pod.id', 22);
+    expect(start).toBe(5);
+    expect(end).toBe(22);
+  });
+
+  it('should stop at non-identifier characters like {', () => {
+    // "kubernetes.pod.id{" with cursor before "{" (col 17, 0-based)
+    const { start, end } = getDottedIdentifierBounds('kubernetes.pod.id{', 17);
+    expect(start).toBe(0);
+    expect(end).toBe(17);
+  });
+
+  it('should handle empty line', () => {
+    const { start, end } = getDottedIdentifierBounds('', 0);
+    expect(start).toBe(0);
+    expect(end).toBe(0);
+  });
+
+  it('should handle metric with colon', () => {
+    const { start, end } = getDottedIdentifierBounds('namespace:container.cpu', 23);
+    expect(start).toBe(0);
+    expect(end).toBe(23);
+  });
+});

--- a/src/components/monaco-query-field/monaco-completion-provider/getDottedIdentifierBounds.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/getDottedIdentifierBounds.ts
@@ -1,0 +1,15 @@
+// Find the start and end offsets (0-based) of the dotted identifier around the cursor.
+// Monaco's getWordAtPosition treats dots as word boundaries, so we scan manually.
+export function getDottedIdentifierBounds(lineContent: string, cursorCol0: number): { start: number; end: number } {
+  let start = cursorCol0;
+  while (start > 0 && /[a-zA-Z0-9_.:]/.test(lineContent[start - 1])) {
+    start--;
+  }
+
+  let end = cursorCol0;
+  while (end < lineContent.length && /[a-zA-Z0-9_.:]/.test(lineContent[end])) {
+    end++;
+  }
+
+  return { start, end };
+}

--- a/src/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -23,6 +23,7 @@ import type { Monaco, monacoTypes } from '@grafana/ui';
 import { escapeMetricNameSpecialCharacters } from '../../../language_utils';
 
 import { CompletionType, DataProvider, getCompletions } from './completions';
+import { getDottedIdentifierBounds } from './getDottedIdentifierBounds';
 import { getSituation } from './situation';
 import { NeverCaseError } from './util';
 
@@ -67,6 +68,24 @@ function getMonacoCompletionItemKind(type: CompletionType, monaco: Monaco): mona
       throw new NeverCaseError();
   }
 }
+
+// Get Monaco range that spans the full dotted identifier around the cursor (e.g. "kubernetes.pod.id").
+function getDottedWordRange(
+  model: monacoTypes.editor.ITextModel,
+  position: monacoTypes.Position,
+  monaco: Monaco
+): monacoTypes.Range {
+  const lineContent = model.getLineContent(position.lineNumber);
+  const { start, end } = getDottedIdentifierBounds(lineContent, position.column - 1);
+
+  return monaco.Range.lift({
+    startLineNumber: position.lineNumber,
+    endLineNumber: position.lineNumber,
+    startColumn: start + 1, // 1-based
+    endColumn: end + 1,     // 1-based
+  });
+}
+
 export function getCompletionProvider(
   monaco: Monaco,
   dataProvider: DataProvider
@@ -85,6 +104,7 @@ export function getCompletionProvider(
           endColumn: word.endColumn,
         })
         : monaco.Range.fromPositions(position);
+    const metricNameRange = getDottedWordRange(model, position, monaco);
     // documentation says `position` will be "adjusted" in `getOffsetAt`
     // i don't know what that means, to be sure i clone it
     const positionClone = {
@@ -106,7 +126,7 @@ export function getCompletionProvider(
         detail: item.detail,
         documentation: { value: item.documentation } as IMarkdownString,
         sortText: index.toString().padStart(maxIndexDigits, '0'), // to force the order we have
-        range,
+        range: item.type === CompletionType.metricName ? metricNameRange : range,
         command: item.triggerOnInsert
           ? {
             id: 'editor.action.triggerSuggest',


### PR DESCRIPTION
Related issue: #493 

### Describe Your Changes

fix: autocomplete inserts duplicate prefix for dotted metric names

  Monaco's getWordAtPosition() treats dots as word boundaries, so for a
  metric like "kubernetes.pod.id" it only recognizes "pod" as the current
  word. The completion replace range covered only "pod", but insertText
  contained the full name, resulting in "kubernetes.kubernetes.pod.id".

  Fix by computing a custom range for metric name completions that scans
  backwards over dots to cover the entire dotted prefix the user has typed.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes autocomplete for dotted and colon-separated metric names to prevent duplicate prefixes (e.g., avoids "kubernetes.kubernetes.pod.id"). Uses a custom replace range that spans the full identifier around the cursor.

- **Bug Fixes**
  - Replace the entire `[a-zA-Z0-9_.:]` identifier for `metricName` completions; other types keep Monaco’s default range.
  - Add unit tests for edge cases and update `CHANGELOG.md` (see #493).

<sup>Written for commit 856c81175713b305234f037a6fcbc62b35e48a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

