### PR TITLE
fix: enforce 5min minimum step for instant queries to prevent no-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* BUGFIX: fix instant queries returning no data when the auto-calculated step is smaller than the metric scrape interval. The minimum step for instant queries is now enforced at 5 minutes unless the user explicitly sets a lower value via the `Min step` field. See [#491](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/491).
 * BUGFIX: fix autocomplete inserting duplicate prefix for metric names containing dots (e.g. `kubernetes.pod.id`). See [#493](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/493).
 
 ## v0.23.4

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -297,15 +297,15 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 	expected = []*data.Frame{
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 300000}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "100"}, []float64{1}),
 		).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: matrix}}),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 300000}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "500"}, []float64{2}),
 		).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: matrix}}),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 300000}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "200"}, []float64{3}),
 		).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: matrix}}),
 	}

--- a/pkg/plugin/step.go
+++ b/pkg/plugin/step.go
@@ -12,13 +12,12 @@ import (
 )
 
 const (
-	varInterval            = "$__interval"
-	varIntervalMs          = "$__interval_ms"
-	varRange               = "$__range"
-	varRangeS              = "$__range_s"
-	varRangeMs             = "$__range_ms"
-	varRateInterval        = "$__rate_interval"
-	defaultIntervalMsValue = 1000
+	varInterval     = "$__interval"
+	varIntervalMs   = "$__interval_ms"
+	varRange        = "$__range"
+	varRangeS       = "$__range_s"
+	varRangeMs      = "$__range_ms"
+	varRateInterval = "$__rate_interval"
 )
 
 var (
@@ -37,12 +36,16 @@ func (q *Query) getIntervalFrom(defaultInterval time.Duration) (time.Duration, e
 	if interval == "0s" {
 		interval = ""
 	}
+	// userSetInterval is true when the user explicitly set a "Min step" value in the query editor.
+	// Auto-calculated intervals (IntervalMs, TimeInterval) are subject to the 5min minimum for instant queries.
+	userSetInterval := interval != ""
 	if interval == "" {
-		if q.IntervalMs == defaultIntervalMsValue && q.Instant {
-			return instantQueryDefaultStep, nil
-		}
 		if q.IntervalMs != 0 {
-			return time.Duration(q.IntervalMs) * time.Millisecond, nil
+			d := time.Duration(q.IntervalMs) * time.Millisecond
+			if q.Instant && d < instantQueryDefaultStep {
+				return instantQueryDefaultStep, nil
+			}
+			return d, nil
 		}
 	}
 	if interval == "" && q.TimeInterval != "" {
@@ -54,7 +57,9 @@ func (q *Query) getIntervalFrom(defaultInterval time.Duration) (time.Duration, e
 		if err != nil {
 			return time.Duration(0), err
 		}
-
+		if q.Instant && !userSetInterval && parsedInterval < instantQueryDefaultStep {
+			return instantQueryDefaultStep, nil
+		}
 		return parsedInterval, nil
 	}
 

--- a/pkg/plugin/step_test.go
+++ b/pkg/plugin/step_test.go
@@ -264,6 +264,46 @@ func Test_calculateStep(t *testing.T) {
 		want: "5m0s",
 	}
 	f(o)
+
+	// instant query with auto-calculated 15s interval (below 5min minimum)
+	o = opts{
+		query: &Query{
+			Instant:    true,
+			IntervalMs: 15000,
+		},
+		want: "5m0s",
+	}
+	f(o)
+
+	// instant query with auto-calculated 10min interval (above 5min minimum, keep as-is)
+	o = opts{
+		query: &Query{
+			Instant:    true,
+			IntervalMs: 600000,
+		},
+		want: "10m0s",
+	}
+	f(o)
+
+	// instant query with datasource TimeInterval "30s" and no user-set interval
+	o = opts{
+		query: &Query{
+			Instant:      true,
+			TimeInterval: "30s",
+		},
+		want: "5m0s",
+	}
+	f(o)
+
+	// instant query with user-set Min step "10s" — user override bypasses 5min minimum
+	o = opts{
+		query: &Query{
+			Instant:  true,
+			Interval: "10s",
+		},
+		want: "10s",
+	}
+	f(o)
 }
 
 func Test_calculateRateInterval(t *testing.T) {


### PR DESCRIPTION
Related issue: #491 

Enforce a `5-minute` minimum step for instant queries to prevent no-data.

VictoriaMetrics instant queries use the step parameter as a lookback window — they search for the most recent data point within the last `step` seconds. When Grafana auto-calculates a small `intervalMs` (e.g. 15s for a Stats panel), the instant query may return no data if the metric scrape interval is close to or equal to the step value.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce a 5-minute minimum step for instant queries to prevent empty results when Grafana auto-calculates very small intervals. User-set `Min step` still takes precedence. See #491.

- **Bug Fixes**
  - For instant queries, if auto `IntervalMs` or datasource `TimeInterval` is below 5m, use 5m as the step.
  - Respect user override via `Min step`; if set, use it even if lower than 5m.
  - Added tests for these scenarios and updated the changelog.

<sup>Written for commit 1ff3976bf0b7127cf6dbe0791fa95cd2edb34143. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

