### PR TITLE
Build victoriametrics-datasource backend plugin binary for OpenBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.25.0
 
-* FEATURE: provide a plugin binary for OpenBSD
+* FEATURE: provide a plugin binary for OpenBSD. Thanks @ledeuns for contributing.
 
 ## v0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## tip
 
+## v0.25.0
+
+* FEATURE: provide a plugin binary for OpenBSD
+
 ## v0.24.0
 
 * FEATURE: store WITH templates as a hidden dashboard variable instead of datasource settings. Templates are now automatically exported/imported with dashboards and support Grafana variable reactivity. See [#490](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/490).

--- a/Magefile.go
+++ b/Magefile.go
@@ -25,7 +25,10 @@ func Build() {
 	freebsd := func() error {
 		return b.Custom("freebsd", "amd64")
 	}
-	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, linuxS390, freebsd)
+	openbsd := func() error {
+		return b.Custom("openbsd", "amd64")
+	}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, linuxS390, freebsd, openbsd)
 }
 
 // Default configures the default target.


### PR DESCRIPTION
### Describe Your Changes

Build a `victoriametrics_metrics_backend_plugin_openbsd_amd64` binary for OpenBSD.

OpenBSD provides a VictoriaMetrics port but it is not usable with Grafana since the plugin does not exists.
This diff just adds the corresponding system declaration in Magefile.go.

Tested on an OpenBSD-current with VictoriaMetrics v1.119.0 and Grafana v12.4.2.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the `victoriametrics_metrics_backend_plugin_openbsd_amd64` binary to enable the VictoriaMetrics Grafana backend plugin on OpenBSD. Updates `CHANGELOG.md` with a `v0.25.0` entry noting OpenBSD support and acknowledging the contributor.

- **New Features**
  - Add `openbsd/amd64` build via `b.Custom("openbsd", "amd64")` and include it in `mg.Deps(...)`.

<sup>Written for commit 3f0af92e57d8a8a64b292309be25bc5542e4ff2d. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

