### PR TITLE
fix: support __name__ label as metric name in Export Data (#508)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ cypress/videos
 # Docker
 .cache
 gocache-for-docker
+
+.DS_Store

--- a/src/components/ExportData/utils.test.ts
+++ b/src/components/ExportData/utils.test.ts
@@ -107,4 +107,49 @@ describe('extractMetricSelectors', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({ selector: 'metric', metric: 'metric' });
   });
+
+  it('should resolve metric name from positive __name__ label matcher', () => {
+    expect(extractMetricSelectors('{__name__="vm_rows"}')).toEqual([
+      { selector: '{__name__="vm_rows"}', metric: 'vm_rows' },
+    ]);
+  });
+
+  it('should resolve __name__ alongside other label matchers (bug #508)', () => {
+    expect(extractMetricSelectors('{type!~"indexdb.*", __name__="vm_rows"}')).toEqual([
+      { selector: '{type!~"indexdb.*", __name__="vm_rows"}', metric: 'vm_rows' },
+    ]);
+  });
+
+  it('should resolve __name__ when it is the first matcher', () => {
+    expect(extractMetricSelectors('{__name__="vm_rows", job="api"}')).toEqual([
+      { selector: '{__name__="vm_rows", job="api"}', metric: 'vm_rows' },
+    ]);
+  });
+
+  it('should not treat negated __name__ as the metric name', () => {
+    expect(extractMetricSelectors('{__name__!="vm_rows"}')).toEqual([
+      { selector: '{__name__!="vm_rows"}', metric: '' },
+    ]);
+  });
+
+  it('should not treat regex __name__ matcher as the metric name', () => {
+    expect(extractMetricSelectors('{__name__=~"vm_.*"}')).toEqual([
+      { selector: '{__name__=~"vm_.*"}', metric: '' },
+    ]);
+  });
+
+  it('should resolve __name__ inside nested function calls', () => {
+    expect(extractMetricSelectors('sum(rate({__name__="vm_rows"}[5m]))')).toEqual([
+      { selector: '{__name__="vm_rows"}', metric: 'vm_rows' },
+    ]);
+  });
+
+  it('should not return error-recovered VectorSelector when parser fails on special chars', () => {
+    // 'CellTemp(1)[°C]{...}' is invalid PromQL — the parser recovers by truncating
+    // the input into a VectorSelector "CellTemp(1" with surrounding error nodes.
+    // Such partial parses must never surface as valid selectors.
+    const result = extractMetricSelectors('CellTemp(1)[°C]{station="Solvallen2",timest="10min"}');
+    expect(result.map((s) => s.selector)).not.toContain('CellTemp(1');
+    expect(result.find((s) => s.metric === 'CellTemp')).toBeUndefined();
+  });
 });

--- a/src/components/ExportData/utils.ts
+++ b/src/components/ExportData/utils.ts
@@ -1,9 +1,23 @@
-import { MetricIdentifier, parser, VectorSelector } from 'lezer-metricsql';
+import { SyntaxNode } from '@lezer/common';
+import {
+  LabelMatcher,
+  LabelMatchers,
+  LabelName,
+  MatchOp,
+  MetricIdentifier,
+  parser,
+  StringLiteral,
+  VectorSelector,
+} from 'lezer-metricsql';
 
 export interface MetricSelector {
   /** Full text of the vector selector, e.g. 'http_requests_total{job="api"}' */
   selector: string;
-  /** Metric name, e.g. 'http_requests_total'. Empty string if selector has only labels */
+  /**
+   * Metric name, e.g. 'http_requests_total'. Resolved either from the leading
+   * identifier or from a positive `__name__="..."` label matcher. Empty when
+   * neither is present.
+   */
   metric: string;
 }
 
@@ -27,17 +41,29 @@ export function extractMetricSelectors(expr: string): MetricSelector[] {
   tree.iterate({
     enter: (nodeRef): false | void => {
       if (nodeRef.type.id === VectorSelector) {
+        const node = nodeRef.node;
+
+        // Skip selectors produced by parser error recovery — e.g. invalid input
+        // 'CellTemp(1)[°C]{...}' yields a truncated VectorSelector 'CellTemp(1'
+        // surrounded by error nodes. Treating it as valid would silently corrupt
+        // downstream API requests.
+        if (subtreeHasErrors(node)) {
+          return false;
+        }
+
         const selector = expr.substring(nodeRef.from, nodeRef.to);
 
         if (!seen.has(selector)) {
           seen.add(selector);
 
           let metric = '';
-          // Look for MetricIdentifier child node to extract metric name
-          const node = nodeRef.node;
           const metricNode = node.getChild(MetricIdentifier);
           if (metricNode) {
             metric = expr.substring(metricNode.from, metricNode.to);
+          } else {
+            // No leading identifier — fall back to a positive `__name__="..."`
+            // label matcher, which is semantically the metric name.
+            metric = extractNameFromLabelMatchers(expr, node);
           }
 
           selectors.push({ selector, metric });
@@ -49,4 +75,50 @@ export function extractMetricSelectors(expr: string): MetricSelector[] {
   });
 
   return selectors;
+}
+
+function subtreeHasErrors(node: SyntaxNode): boolean {
+  let found = false;
+  node.cursor().iterate((cursor): false | void => {
+    if (cursor.type.isError) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+}
+
+function extractNameFromLabelMatchers(expr: string, vectorSelectorNode: SyntaxNode): string {
+  const labelMatchersNode = vectorSelectorNode.getChild(LabelMatchers);
+  if (!labelMatchersNode) {
+    return '';
+  }
+
+  // LabelMatcher is nested under LabelMatchList (which can recurse), so walk
+  // the subtree instead of asking for direct children.
+  let result = '';
+  labelMatchersNode.cursor().iterate((cursor) => {
+    if (result !== '' || cursor.type.id !== LabelMatcher) {
+      return;
+    }
+    const matcher = cursor.node;
+    const nameNode = matcher.getChild(LabelName);
+    const opNode = matcher.getChild(MatchOp);
+    const valueNode = matcher.getChild(StringLiteral);
+    if (!nameNode || !opNode || !valueNode) {
+      return;
+    }
+    if (expr.substring(nameNode.from, nameNode.to) !== '__name__') {
+      return;
+    }
+    if (expr.substring(opNode.from, opNode.to) !== '=') {
+      return;
+    }
+    // StringLiteral spans the surrounding quotes — strip one char from each end.
+    if (valueNode.to - valueNode.from < 2) {
+      return;
+    }
+    result = expr.substring(valueNode.from + 1, valueNode.to - 1);
+  });
+  return result;
 }

--- a/src/components/PrometheusMetricsBrowser.test.tsx
+++ b/src/components/PrometheusMetricsBrowser.test.tsx
@@ -1,0 +1,72 @@
+import { buildSelector, SelectableLabel } from './PrometheusMetricsBrowser';
+
+describe('buildSelector', () => {
+  it('should wrap special-char metric names in __name__="..." form', () => {
+    // Metric names like 'CellTemp(1)[°C]' contain characters outside
+    // [a-zA-Z_:][a-zA-Z0-9_:]* and cannot be the leading identifier of a
+    // PromQL selector — they must be expressed via __name__ instead.
+    const labels: SelectableLabel[] = [
+      {
+        name: '__name__',
+        values: [{ name: 'CellTemp(1)[°C]', selected: true }],
+      },
+      {
+        name: 'station',
+        selected: true,
+        values: [{ name: 'Moon', selected: true }],
+      },
+    ];
+
+    expect(buildSelector(labels)).toBe('{__name__="CellTemp(1)[°C]",station="Moon"}');
+  });
+
+  it('should keep regular metric names as the leading identifier', () => {
+    const labels: SelectableLabel[] = [
+      {
+        name: '__name__',
+        values: [{ name: 'http_requests_total', selected: true }],
+      },
+      {
+        name: 'job',
+        selected: true,
+        values: [{ name: 'api', selected: true }],
+      },
+    ];
+
+    expect(buildSelector(labels)).toBe('http_requests_total{job="api"}');
+  });
+
+  it('should keep colon-namespaced metric names as leading identifier', () => {
+    const labels: SelectableLabel[] = [
+      {
+        name: '__name__',
+        values: [{ name: 'foo:bar:rate1m', selected: true }],
+      },
+    ];
+
+    expect(buildSelector(labels)).toBe('foo:bar:rate1m{}');
+  });
+
+  it('should produce a label-only selector when no metric is selected', () => {
+    const labels: SelectableLabel[] = [
+      {
+        name: 'station',
+        selected: true,
+        values: [{ name: 'Moon', selected: true }],
+      },
+    ];
+
+    expect(buildSelector(labels)).toBe('{station="Moon"}');
+  });
+
+  it('should escape quotes inside special-char metric names', () => {
+    const labels: SelectableLabel[] = [
+      {
+        name: '__name__',
+        values: [{ name: 'weird"name', selected: true }],
+      },
+    ];
+
+    expect(buildSelector(labels)).toBe('{__name__="weird\\"name"}');
+  });
+});

--- a/src/components/PrometheusMetricsBrowser.tsx
+++ b/src/components/PrometheusMetricsBrowser.tsx
@@ -39,6 +39,9 @@ import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from
 const EMPTY_SELECTOR = '{}';
 const METRIC_LABEL = '__name__';
 const LIST_ITEM_SIZE = 25;
+// PromQL identifier grammar: leading [a-zA-Z_:] then [a-zA-Z0-9_:]*. Names
+// outside this set (e.g. 'CellTemp(1)[°C]') must be expressed via __name__.
+const METRIC_NAME_RE = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
 
 export interface BrowserProps {
   languageProvider: PromQlLanguageProvider;
@@ -92,6 +95,12 @@ export function buildSelector(labels: SelectableLabel[]): string {
         }
       }
     }
+  }
+  // Metric names with characters outside the PromQL identifier grammar must
+  // be emitted as a __name__="..." matcher to stay parseable downstream.
+  if (singleMetric && !METRIC_NAME_RE.test(singleMetric)) {
+    selectedLabels.unshift(`${METRIC_LABEL}="${escapeLabelValueInExactSelector(singleMetric)}"`);
+    singleMetric = '';
   }
   return [singleMetric, '{', selectedLabels.join(','), '}'].join('');
 }


### PR DESCRIPTION
Related issue: #508

### Describe Your Changes

Vector selectors like {type!~"indexdb.*", __name__="vm_rows"} used to be filtered out of the Export Data modal because extractMetricSelectors only looked for a leading MetricIdentifier. Resolve the metric from a positive `__name__="..."` label matcher when no identifier is present, which lets such selectors pass the existing s.metric !== '' filter and flow through to the VictoriaMetrics match[] API unchanged. Negated and regex __name__ matchers stay non-resolving by design.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Export Data so selectors that use the `__name__` label are accepted and metric names with special characters stay parseable (fixes #508). Selectors like `{type!~"indexdb.*", __name__="vm_rows"}` and `{__name__="CellTemp(1)[°C]",station="X"}` now export correctly.

- **Bug Fixes**
  - Resolve metric name from positive `__name__="..."` when no identifier; keep negated/regex `__name__` non-resolving.
  - In `PrometheusMetricsBrowser`, wrap special-character metric names as `__name__="..."` to generate valid selectors.
  - Skip `VectorSelector` subtrees with parser error nodes to avoid exporting truncated identifiers from invalid PromQL.
  - Added tests for `buildSelector`, special-char metrics, mixed label matchers, nested functions, and the parser-error edge case.

<sup>Written for commit 9dc4f37115aab85e3c16b8b30cbfd235a4b2edfa. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

