### PR TITLE
docs(changelog): move v0.25.0 entries to tip and log Export Data fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## tip
 
-## v0.25.0
-
 * FEATURE: provide a plugin binary for OpenBSD. Thanks @ledeuns for contributing.
+
+* BUGFIX: preserve metric names containing special characters (e.g. `CellTemp(1)[°C]`) in the Export Data flow. Such names are now wrapped into a `__name__="..."` matcher, producing a parseable selector. See [#508](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/508).
 
 ## v0.24.0
 


### PR DESCRIPTION
### Describe Your Changes

- Remove the v0.25.0 heading and roll its OpenBSD binary FEATURE entry back under tip
- Add a BUGFIX entry for #508 covering preservation of special-character metric names in the Export Data flow

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the OpenBSD plugin binary feature back under tip and removed the premature v0.25.0 section. Added a bugfix entry for Export Data to preserve metric names with special characters (e.g., CellTemp(1)[°C]) by wrapping them in a `__name__="..."` matcher for a parseable selector.

<sup>Written for commit eb19748b768b48814fddbc2e1ef0128b5419cf01. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

