### PR TITLE
fix: load Export Data labels independently of panel response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * BUGFIX: preserve metric names containing special characters (e.g. `CellTemp(1)[°C]`) in the Export Data flow. Such names are now wrapped into a `__name__="..."` matcher, producing a parseable selector. See [#508](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/508).
 * BUGFIX: fix selector validation errors in the Metrics Browser being reported as "undefined series found". Errors are now shown as a clear message. See [#471](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/471). Thanks to @dmedovich for contributing.
+* BUGFIX: make label keys in the Export Data CSV options available even when the query has not been executed yet. Previously they were derived from the current panel response, so opening the export dialog before running the query (or on a query that returned no data) left the labels picker empty.
 
 ## v0.24.0
 

--- a/src/components/ExportData/CsvOptionsFields.tsx
+++ b/src/components/ExportData/CsvOptionsFields.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+
+import { ComboboxOption, Field, Icon, Input, MultiCombobox, Select, Tooltip } from '@grafana/ui';
+
+import { formatDescriptions } from '../../utils/convertLDMLLayoutToGoTimeLayout';
+
+import { TIMESTAMP_OPTIONS } from './constants';
+import { TimestampFormat } from './types';
+
+interface CsvOptionsFieldsProps {
+  timestampFormat: TimestampFormat;
+  onTimestampFormatChange: (format: TimestampFormat) => void;
+  customLayout: string;
+  onCustomLayoutChange: (layout: string) => void;
+  availableLabels: Array<ComboboxOption<string>>;
+  selectedLabels: string[];
+  onSelectedLabelsChange: (labels: string[]) => void;
+  labelsLoading: boolean;
+}
+
+export const CsvOptionsFields: React.FC<CsvOptionsFieldsProps> = ({
+  timestampFormat,
+  onTimestampFormatChange,
+  customLayout,
+  onCustomLayoutChange,
+  availableLabels,
+  selectedLabels,
+  onSelectedLabelsChange,
+  labelsLoading,
+}) => {
+  const customLayoutDescription = useMemo(() => {
+    const helpText = Object.entries(formatDescriptions).reduce((acc, [key, value]) => {
+      acc += `${key}: ${value}\n`;
+      return acc;
+    }, '');
+    return (
+      <span>
+        Custom layout format
+        <Tooltip placement='top' content={<pre>{helpText}</pre>} theme='info'>
+          <Icon title='Format' name='info-circle' size='sm' width={16} height={16} />
+        </Tooltip>
+      </span>
+    );
+  }, []);
+
+  return (
+    <>
+      <Field
+        label='Timestamp format'
+        description='Timestamps are emitted in UTC; custom layouts cannot shift the timezone.'
+      >
+        <Select
+          options={TIMESTAMP_OPTIONS}
+          value={timestampFormat}
+          onChange={(v) => v.value && onTimestampFormatChange(v.value)}
+        />
+      </Field>
+
+      {timestampFormat === 'custom' && (
+        <Field label='Custom layout' description={customLayoutDescription}>
+          <Input
+            value={customLayout}
+            onChange={(e) => onCustomLayoutChange(e.currentTarget.value)}
+            placeholder='YYYY-MM-DDTHH:mm:ss.SSSSSSSSSZ'
+          />
+        </Field>
+      )}
+
+      <Field label='Labels' description='Select labels to include as additional CSV columns'>
+        <MultiCombobox
+          options={availableLabels}
+          value={selectedLabels}
+          onChange={(selected) => onSelectedLabelsChange(selected.map((s) => s.value))}
+          placeholder={labelsLoading ? 'Loading labels...' : 'Select labels...'}
+          loading={labelsLoading}
+          isClearable
+          enableAllOption
+        />
+      </Field>
+    </>
+  );
+};

--- a/src/components/ExportData/ExportDataModal.tsx
+++ b/src/components/ExportData/ExportDataModal.tsx
@@ -1,149 +1,51 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
-import { getDefaultTimeRange, GrafanaTheme2, SelectableValue } from '@grafana/data';
-import {
-  Alert,
-  Button,
-  Field,
-  Icon,
-  Input,
-  LinkButton,
-  Modal,
-  MultiSelect,
-  RadioButtonGroup,
-  Select,
-  Tooltip,
-  useStyles2,
-} from '@grafana/ui';
+import { getDefaultTimeRange, GrafanaTheme2 } from '@grafana/data';
+import { Alert, Button, Field, LinkButton, Modal, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
-import { convertLDMLLayoutToGoTimeLayout, formatDescriptions } from '../../utils/convertLDMLLayoutToGoTimeLayout';
-
-import { ExportDataModalProps, ExportFormat, ExportOptions, TimestampFormat } from './types';
-import { extractMetricSelectors } from './utils';
-
-const FILE_FORMATS = {
-  json: { ext: 'jsonl', apiPath: 'api/v1/export' },
-  csv: { ext: 'csv', apiPath: 'api/v1/export/csv' }
-} as const;
-
-const toUnixSeconds = (milliseconds: number): number => Math.floor(milliseconds / 1000);
-
-const formatOptions = [
-  { label: 'JSON Line', value: 'json' as ExportFormat },
-  { label: 'CSV', value: 'csv' as ExportFormat },
-];
-
-const timestampOptions = [
-  { label: 'Unix Seconds', value: 'unix_s' as TimestampFormat, description: 'Unix timestamp in seconds' },
-  { label: 'Unix Milliseconds', value: 'unix_ms' as TimestampFormat, description: 'Unix timestamp in milliseconds' },
-  { label: 'Unix Nanoseconds', value: 'unix_ns' as TimestampFormat, description: 'Unix timestamp in nanoseconds' },
-  { label: 'RFC3339', value: 'rfc3339' as TimestampFormat, description: 'RFC3339 format (e.g., 2006-01-02T15:04:05Z)' },
-  { label: 'Custom', value: 'custom' as TimestampFormat, description: 'Custom Go time layout' },
-];
+import { CsvOptionsFields } from './CsvOptionsFields';
+import { SelectorsField } from './SelectorsField';
+import { TimeRangeField } from './TimeRangeField';
+import { DEFAULT_CUSTOM_LAYOUT, FORMAT_OPTIONS } from './constants';
+import { ExportDataModalProps, ExportOptions } from './types';
+import { useExportLabels } from './useExportLabels';
+import { useExportSelectors } from './useExportSelectors';
+import { useExportUrl } from './useExportUrl';
 
 export const ExportDataModal: React.FC<ExportDataModalProps> = ({ isOpen, onClose, datasource, query, panelData }) => {
   const styles = useStyles2(getStyles);
   const [options, setOptions] = useState<ExportOptions>({
     format: 'json',
     timestampFormat: 'unix_s',
-    customLayout: 'YYYY-MM-DDThh:mm:ss.SSSZ',
-    selectedLabels: [],
+    customLayout: DEFAULT_CUSTOM_LAYOUT,
   });
 
-  const customLayoutDescription = useMemo(() => {
-    const helpText = Object.entries(formatDescriptions).reduce((acc, [key, value]) => {
-      acc += `${key}: ${value}\n`;
-      return acc;
-    }, '');
-    const helpTooltipContent = <pre>{helpText}</pre>;
-    return (
-      <span>
-        Custom layout format
-        <Tooltip placement='top' content={helpTooltipContent} theme='info'>
-          <Icon title={'Format'} name='info-circle' size='sm' width={16} height={16} />
-        </Tooltip>
-      </span>
-    );
-  }, []);
+  const { validSelectors, selectedSelectors, toggleSelector } = useExportSelectors(datasource, query, panelData);
 
-  const availableLabels = useMemo((): Array<SelectableValue<string>> => {
-    const labelSet = new Set<string>();
-    panelData?.series?.forEach((frame) => {
-      frame.fields.forEach((field) => {
-        if (field.labels) {
-          Object.keys(field.labels).forEach((key) => {
-            if (key !== '__name__') {
-              labelSet.add(key);
-            }
-          });
-        }
-      });
-    });
-    return Array.from(labelSet)
-      .sort()
-      .map((label) => ({ label, value: label }));
-  }, [panelData?.series]);
-
-  const resolvedExpr = useMemo(() => {
-    return datasource.getTemplateSrv().replace(query.expr, panelData?.request?.scopedVars);
-  }, [datasource, query.expr, panelData?.request?.scopedVars]);
-
-  const metricSelectors = useMemo(() => {
-    return extractMetricSelectors(resolvedExpr);
-  }, [resolvedExpr]);
-
-  const validSelectors = metricSelectors;
-
-  const [selectedSelectors, setSelectedSelectors] = useState<string[]>([]);
-
-  useEffect(() => {
-    setSelectedSelectors(validSelectors.map((s) => s.selector));
-  }, [validSelectors]);
-
-  const canExport = selectedSelectors.length > 0;
-
-  const handleToggleSelector = useCallback((selector: string) => {
-    setSelectedSelectors((prev) =>
-      prev.includes(selector) ? prev.filter((s) => s !== selector) : [...prev, selector]
-    );
-  }, []);
+  const {
+    availableLabels,
+    selectedLabels,
+    setSelectedLabels,
+    isLoading: labelsLoading,
+  } = useExportLabels({
+    datasource,
+    isOpen,
+    isCsv: options.format === 'csv',
+    selectors: selectedSelectors,
+    panelData,
+  });
 
   const timeRange = panelData?.timeRange || getDefaultTimeRange();
-  const start = timeRange.from.valueOf();
-  const end = timeRange.to.valueOf();
 
-  const buildCsvFormatString = useCallback((): string => {
-    let tsFormat: string = options.timestampFormat;
-    if (options.timestampFormat === 'custom') {
-      const goLayout = convertLDMLLayoutToGoTimeLayout(options.customLayout);
-      tsFormat = `custom:${goLayout}`;
-    }
-    let fmt = `__timestamp__:${tsFormat},__name__`;
-    if (options.selectedLabels.length > 0) {
-      fmt += ',' + options.selectedLabels.join(',');
-    }
-    fmt += ',__value__';
-    return fmt;
-  }, [options]);
-
-  const { exportUrl, exportFileName } = useMemo(() => {
-    if (!canExport) {
-      return { exportUrl: '', exportFileName: '' };
-    }
-    const formatConfig = FILE_FORMATS[options.format];
-    const params = buildExportParams(
-      selectedSelectors,
-      toUnixSeconds(start),
-      toUnixSeconds(end),
-      options.format,
-      options.format === 'csv' ? buildCsvFormatString() : undefined
-    );
-    return {
-      exportUrl: `api/datasources/uid/${datasource.uid}/resources/${formatConfig.apiPath}?${params.toString()}`,
-      exportFileName: generateFileName(selectedSelectors, Date.now(), formatConfig.ext),
-    };
-  }, [canExport, datasource.uid, selectedSelectors, start, end, options.format, buildCsvFormatString]);
+  const { exportUrl, exportFileName, canExport } = useExportUrl({
+    datasource,
+    selectors: selectedSelectors,
+    options,
+    selectedLabels,
+    startMs: timeRange.from.valueOf(),
+    endMs: timeRange.to.valueOf(),
+  });
 
   return (
     <Modal title='Export Data' isOpen={isOpen} onDismiss={onClose}>
@@ -156,75 +58,32 @@ export const ExportDataModal: React.FC<ExportDataModalProps> = ({ isOpen, onClos
 
         <Field label='Format'>
           <RadioButtonGroup
-            options={formatOptions}
+            options={FORMAT_OPTIONS}
             value={options.format}
             onChange={(value) => setOptions({ ...options, format: value })}
           />
         </Field>
 
         {options.format === 'csv' && (
-          <>
-            <Field label='Timestamp format'>
-              <Select
-                options={timestampOptions}
-                value={options.timestampFormat}
-                onChange={(v) => v.value && setOptions({ ...options, timestampFormat: v.value })}
-              />
-            </Field>
-
-            {options.timestampFormat === 'custom' && (
-              <Field label='Custom layout' description={customLayoutDescription}>
-                <Input
-                  value={options.customLayout}
-                  onChange={(e) => setOptions({ ...options, customLayout: e.currentTarget.value })}
-                  placeholder='YYYY-MM-DDThh:mm:ss.SSSSSSSSSZ'
-                />
-              </Field>
-            )}
-
-            {availableLabels.length > 0 && (
-              <Field label='Labels' description='Select labels to include as additional CSV columns'>
-                <MultiSelect
-                  options={availableLabels}
-                  value={options.selectedLabels}
-                  onChange={(selected) => setOptions({ ...options, selectedLabels: selected.map((s) => s.value!) })}
-                  placeholder='Select labels...'
-                  isClearable
-                />
-              </Field>
-            )}
-          </>
+          <CsvOptionsFields
+            timestampFormat={options.timestampFormat}
+            onTimestampFormatChange={(format) => setOptions({ ...options, timestampFormat: format })}
+            customLayout={options.customLayout}
+            onCustomLayoutChange={(layout) => setOptions({ ...options, customLayout: layout })}
+            availableLabels={availableLabels}
+            selectedLabels={selectedLabels}
+            onSelectedLabelsChange={setSelectedLabels}
+            labelsLoading={labelsLoading}
+          />
         )}
 
-        <Field label='Time range'>
-          <div className={styles.timeRange}>
-            {timeRange.from.format('YYYY-MM-DD HH:mm:ss')} — {timeRange.to.format('YYYY-MM-DD HH:mm:ss')}
-          </div>
-        </Field>
+        <TimeRangeField timeRange={timeRange} />
 
-        {validSelectors.length === 1 && (
-          <Field label='Metric'>
-            <div className={styles.metricSelector}>{validSelectors[0].selector}</div>
-          </Field>
-        )}
-
-        {validSelectors.length > 1 && (
-          <Field label='Select metrics to export'>
-            <div className={styles.selectorList}>
-              {validSelectors.map((s) => (
-                <label key={s.selector} className={styles.selectorOption}>
-                  <input
-                    type='checkbox'
-                    value={s.selector}
-                    checked={selectedSelectors.includes(s.selector)}
-                    onChange={() => handleToggleSelector(s.selector)}
-                  />
-                  <span className={styles.selectorLabel}>{s.selector}</span>
-                </label>
-              ))}
-            </div>
-          </Field>
-        )}
+        <SelectorsField
+          selectors={validSelectors}
+          selectedSelectors={selectedSelectors}
+          onToggle={toggleSelector}
+        />
 
         <div className={styles.actions}>
           <Button variant='secondary' onClick={onClose}>
@@ -246,76 +105,16 @@ export const ExportDataModal: React.FC<ExportDataModalProps> = ({ isOpen, onClos
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => {
-  const infoBox = css({
-    padding: theme.spacing(1),
-    backgroundColor: theme.colors.background.secondary,
-    borderRadius: theme.shape.radius.default,
-    fontFamily: theme.typography.fontFamilyMonospace,
-    fontSize: theme.typography.bodySmall.fontSize,
-  });
-
-  return {
-    content: css({
-      display: 'flex',
-      flexDirection: 'column',
-      gap: theme.spacing(2),
-    }),
-    timeRange: infoBox,
-    metricSelector: css(infoBox, {
-      wordBreak: 'break-all',
-    }),
-    selectorList: css({
-      display: 'flex',
-      flexDirection: 'column',
-      gap: theme.spacing(1),
-    }),
-    selectorOption: css({
-      display: 'flex',
-      alignItems: 'flex-start',
-      gap: theme.spacing(1),
-      cursor: 'pointer',
-      padding: theme.spacing(0.5, 1),
-      borderRadius: theme.shape.radius.default,
-      '&:hover': {
-        backgroundColor: theme.colors.action.hover,
-      },
-    }),
-    selectorLabel: css({
-      fontFamily: theme.typography.fontFamilyMonospace,
-      fontSize: theme.typography.bodySmall.fontSize,
-      wordBreak: 'break-all',
-    }),
-    actions: css({
-      display: 'flex',
-      justifyContent: 'flex-end',
-      gap: theme.spacing(1),
-      marginTop: theme.spacing(2),
-    }),
-  };
-};
-
-const buildExportParams = (
-  selectors: string[],
-  startSec: number,
-  endSec: number,
-  format: string,
-  csvFormat?: string
-): URLSearchParams => {
-  const params = new URLSearchParams();
-  selectors.forEach((selector) => params.append('match[]', selector));
-  params.append('start', startSec.toString());
-  params.append('end', endSec.toString());
-  if (format === 'csv' && csvFormat) {
-    params.append('format', csvFormat);
-  }
-  return params;
-};
-
-const generateFileName = (selectors: string[], timestamp: number, ext: string): string => {
-  if (selectors.length === 1) {
-    return `export-${timestamp}.${ext}`;
-  }
-  const selectorStr = selectors.map((selector) => encodeURIComponent(selector)).join('_');
-  return `export-${selectorStr}-${timestamp}.${ext}`;
-};
+const getStyles = (theme: GrafanaTheme2) => ({
+  content: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  actions: css({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/src/components/ExportData/SelectorsField.tsx
+++ b/src/components/ExportData/SelectorsField.tsx
@@ -1,0 +1,84 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Field, useStyles2 } from '@grafana/ui';
+
+import { MetricSelector } from './utils';
+
+interface SelectorsFieldProps {
+  selectors: MetricSelector[];
+  selectedSelectors: string[];
+  onToggle: (selector: string) => void;
+}
+
+export const SelectorsField: React.FC<SelectorsFieldProps> = ({ selectors, selectedSelectors, onToggle }) => {
+  const styles = useStyles2(getStyles);
+
+  if (selectors.length === 0) {
+    return null;
+  }
+
+  if (selectors.length === 1) {
+    return (
+      <Field label='Metric'>
+        <div className={styles.metricSelector}>{selectors[0].selector}</div>
+      </Field>
+    );
+  }
+
+  return (
+    <Field label='Select metrics to export'>
+      <div className={styles.selectorList}>
+        {selectors.map((s) => (
+          <label key={s.selector} className={styles.selectorOption}>
+            <input
+              type='checkbox'
+              value={s.selector}
+              checked={selectedSelectors.includes(s.selector)}
+              onChange={() => onToggle(s.selector)}
+            />
+            <span className={styles.selectorLabel}>{s.selector}</span>
+          </label>
+        ))}
+      </div>
+    </Field>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const infoBox = css({
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+  });
+
+  return {
+    metricSelector: css(infoBox, {
+      wordBreak: 'break-all',
+    }),
+    selectorList: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    selectorOption: css({
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: theme.spacing(1),
+      cursor: 'pointer',
+      padding: theme.spacing(0.5, 1),
+      borderRadius: theme.shape.radius.default,
+      '&:hover': {
+        backgroundColor: theme.colors.action.hover,
+      },
+    }),
+    selectorLabel: css({
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.bodySmall.fontSize,
+      wordBreak: 'break-all',
+    }),
+  };
+};

--- a/src/components/ExportData/TimeRangeField.tsx
+++ b/src/components/ExportData/TimeRangeField.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2, TimeRange } from '@grafana/data';
+import { Field, useStyles2 } from '@grafana/ui';
+
+interface TimeRangeFieldProps {
+  timeRange: TimeRange;
+}
+
+export const TimeRangeField: React.FC<TimeRangeFieldProps> = ({ timeRange }) => {
+  const styles = useStyles2(getStyles);
+  return (
+    <Field label='Time range'>
+      <div className={styles.timeRange}>
+        {timeRange.from.format('YYYY-MM-DD HH:mm:ss')} — {timeRange.to.format('YYYY-MM-DD HH:mm:ss')}
+      </div>
+    </Field>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  timeRange: css({
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});

--- a/src/components/ExportData/constants.ts
+++ b/src/components/ExportData/constants.ts
@@ -1,0 +1,21 @@
+import { ExportFormat, TimestampFormat } from './types';
+
+export const FILE_FORMATS = {
+  json: { ext: 'jsonl', apiPath: 'api/v1/export' },
+  csv: { ext: 'csv', apiPath: 'api/v1/export/csv' },
+} as const;
+
+export const FORMAT_OPTIONS: Array<{ label: string; value: ExportFormat }> = [
+  { label: 'JSON Line', value: 'json' },
+  { label: 'CSV', value: 'csv' },
+];
+
+export const TIMESTAMP_OPTIONS: Array<{ label: string; value: TimestampFormat; description: string }> = [
+  { label: 'Unix Seconds', value: 'unix_s', description: 'Unix timestamp in seconds' },
+  { label: 'Unix Milliseconds', value: 'unix_ms', description: 'Unix timestamp in milliseconds' },
+  { label: 'Unix Nanoseconds', value: 'unix_ns', description: 'Unix timestamp in nanoseconds' },
+  { label: 'RFC3339', value: 'rfc3339', description: 'RFC3339 format (e.g., 2006-01-02T15:04:05Z)' },
+  { label: 'Custom', value: 'custom', description: 'Custom Go time layout' },
+];
+
+export const DEFAULT_CUSTOM_LAYOUT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';

--- a/src/components/ExportData/types.ts
+++ b/src/components/ExportData/types.ts
@@ -11,7 +11,6 @@ export interface ExportOptions {
   format: ExportFormat;
   timestampFormat: TimestampFormat;
   customLayout: string;
-  selectedLabels: string[];
 }
 
 export interface ExportDataButtonProps {

--- a/src/components/ExportData/useExportLabels.test.ts
+++ b/src/components/ExportData/useExportLabels.test.ts
@@ -1,0 +1,189 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { PanelData, FieldType, toDataFrame } from '@grafana/data';
+
+import { PrometheusDatasource } from '../../datasource';
+
+import { useExportLabels } from './useExportLabels';
+
+interface MockDatasource {
+  uid: string;
+  getTagKeys: jest.Mock;
+}
+
+type TagKeysResponse = Array<{ text: string }> | Error;
+
+function makeDatasource(responses: TagKeysResponse[]): MockDatasource {
+  let call = 0;
+  const getTagKeys = jest.fn(async () => {
+    const r = responses[call++ % responses.length];
+    if (r instanceof Error) {
+      throw r;
+    }
+    return r;
+  });
+  return { uid: 'ds-uid', getTagKeys };
+}
+
+function tags(...names: string[]): Array<{ text: string }> {
+  return names.map((text) => ({ text }));
+}
+
+function makePanelData(labelKeys: string[]): PanelData {
+  return {
+    series: [
+      toDataFrame({
+        fields: [
+          {
+            name: 'Value',
+            type: FieldType.number,
+            values: [1],
+            labels: Object.fromEntries(labelKeys.map((k) => [k, 'v'])),
+          },
+        ],
+      }),
+    ],
+  } as unknown as PanelData;
+}
+
+const baseArgs = {
+  selectors: ['foo'],
+};
+
+describe('useExportLabels', () => {
+  it('does not fetch when modal is closed', () => {
+    const ds = makeDatasource([tags('job')]);
+    renderHook(() =>
+      useExportLabels({
+        datasource: ds as unknown as PrometheusDatasource,
+        isOpen: false,
+        isCsv: true,
+        ...baseArgs,
+      })
+    );
+    expect(ds.getTagKeys).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when CSV tab is not active', () => {
+    const ds = makeDatasource([tags('job')]);
+    renderHook(() =>
+      useExportLabels({
+        datasource: ds as unknown as PrometheusDatasource,
+        isOpen: true,
+        isCsv: false,
+        ...baseArgs,
+      })
+    );
+    expect(ds.getTagKeys).not.toHaveBeenCalled();
+  });
+
+  it('fetches labels via getTagKeys per selector and default-selects all of them', async () => {
+    const ds = makeDatasource([tags('job', 'instance', '__name__')]);
+    const { result } = renderHook(() =>
+      useExportLabels({
+        datasource: ds as unknown as PrometheusDatasource,
+        isOpen: true,
+        isCsv: true,
+        ...baseArgs,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(ds.getTagKeys).toHaveBeenCalledWith({ series: ['foo'] });
+    // __name__ is filtered out; results are sorted.
+    expect(result.current.availableLabels.map((l) => l.value)).toEqual(['instance', 'job']);
+    expect(result.current.selectedLabels).toEqual(['instance', 'job']);
+  });
+
+  it('passes all selectors to getTagKeys in a single call so requests fan out in parallel', async () => {
+    const ds = makeDatasource([tags('a', 'b')]);
+    const { result } = renderHook(() =>
+      useExportLabels({
+        datasource: ds as unknown as PrometheusDatasource,
+        isOpen: true,
+        isCsv: true,
+        selectors: ['foo', 'bar'],
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(ds.getTagKeys).toHaveBeenCalledTimes(1);
+    expect(ds.getTagKeys).toHaveBeenCalledWith({ series: ['foo', 'bar'] });
+    expect(result.current.availableLabels.map((l) => l.value)).toEqual(['a', 'b']);
+  });
+
+  it('preserves the user selection once setSelectedLabels is called and drops vanished labels on reload', async () => {
+    const ds = makeDatasource([
+      tags('job', 'instance', 'region'),
+      tags('job', 'region'),
+    ]);
+    const { result, rerender } = renderHook(
+      (props: { selectors: string[] }) =>
+        useExportLabels({
+          datasource: ds as unknown as PrometheusDatasource,
+          isOpen: true,
+          isCsv: true,
+          selectors: props.selectors,
+        }),
+      { initialProps: { selectors: ['foo'] } }
+    );
+
+    await waitFor(() => expect(result.current.selectedLabels).toEqual(['instance', 'job', 'region']));
+
+    act(() => result.current.setSelectedLabels(['instance', 'region']));
+    expect(result.current.selectedLabels).toEqual(['instance', 'region']);
+
+    rerender({ selectors: ['bar'] });
+    await waitFor(() => expect(result.current.availableLabels.map((l) => l.value)).toEqual(['job', 'region']));
+
+    // User selection is preserved, but 'instance' is dropped since it disappeared.
+    expect(result.current.selectedLabels).toEqual(['region']);
+  });
+
+  it('falls back to panel-series labels when getTagKeys fails', async () => {
+    const ds = makeDatasource([new Error('boom')]);
+    const panelData = makePanelData(['env', 'service']);
+
+    const { result } = renderHook(() =>
+      useExportLabels({
+        datasource: ds as unknown as PrometheusDatasource,
+        isOpen: true,
+        isCsv: true,
+        ...baseArgs,
+        panelData,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.availableLabels.map((l) => l.value)).toEqual(['env', 'service']);
+    expect(result.current.selectedLabels).toEqual(['env', 'service']);
+  });
+
+  it('preserves the user selection across modal close/reopen', async () => {
+    const ds = makeDatasource([tags('job'), tags('job', 'instance')]);
+
+    const { result, rerender } = renderHook(
+      (props: { isOpen: boolean }) =>
+        useExportLabels({
+          datasource: ds as unknown as PrometheusDatasource,
+          isOpen: props.isOpen,
+          isCsv: true,
+          ...baseArgs,
+        }),
+      { initialProps: { isOpen: true } }
+    );
+
+    await waitFor(() => expect(result.current.selectedLabels).toEqual(['job']));
+    act(() => result.current.setSelectedLabels([]));
+    expect(result.current.selectedLabels).toEqual([]);
+
+    rerender({ isOpen: false });
+    rerender({ isOpen: true });
+
+    // Even when a newly-available label ('instance') appears after reopen, the
+    // empty user selection is preserved — defaults do not re-apply.
+    await waitFor(() => expect(result.current.availableLabels.map((l) => l.value)).toEqual(['instance', 'job']));
+    expect(result.current.selectedLabels).toEqual([]);
+  });
+});

--- a/src/components/ExportData/useExportLabels.ts
+++ b/src/components/ExportData/useExportLabels.ts
@@ -1,0 +1,98 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { DataFrame, PanelData } from '@grafana/data';
+import { ComboboxOption } from '@grafana/ui';
+
+import { PrometheusDatasource } from '../../datasource';
+
+interface UseExportLabelsArgs {
+  datasource: PrometheusDatasource;
+  isOpen: boolean;
+  isCsv: boolean;
+  selectors: string[];
+  panelData?: PanelData;
+}
+
+interface UseExportLabelsResult {
+  availableLabels: Array<ComboboxOption<string>>;
+  selectedLabels: string[];
+  setSelectedLabels: (labels: string[]) => void;
+  isLoading: boolean;
+}
+
+const SEPARATOR = '__separator__';
+
+function collectSeriesLabels(series?: DataFrame[]): string[] {
+  const labelSet = new Set<string>();
+  series?.forEach((frame) => {
+    frame.fields.forEach((field) => {
+      if (field.labels) {
+        Object.keys(field.labels).forEach((key) => {
+          if (key !== '__name__') {
+            labelSet.add(key);
+          }
+        });
+      }
+    });
+  });
+  return Array.from(labelSet).sort();
+}
+
+export function useExportLabels({
+  datasource,
+  isOpen,
+  isCsv,
+  selectors,
+  panelData,
+}: UseExportLabelsArgs): UseExportLabelsResult {
+  const seriesLabels = useMemo(() => collectSeriesLabels(panelData?.series), [panelData?.series]);
+  const [override, setOverride] = useState<string[] | null>(null);
+  const shouldFetch = isOpen && isCsv && selectors.length > 0;
+  const selectorsKey = selectors.join(SEPARATOR);
+
+  const {
+    value: fetchedLabels,
+    loading: isLoading,
+    error: fetchError,
+  } = useAsync(async (): Promise<string[]> => {
+    if (!shouldFetch) {
+      return [];
+    }
+    const tags = (await datasource.getTagKeys({ series: selectors })) as Array<{ text: string }>;
+    const labelSet = new Set<string>();
+    tags.forEach(({ text }) => {
+      if (text !== '__name__') {
+        labelSet.add(text);
+      }
+    });
+    return Array.from(labelSet).sort();
+  }, [datasource, shouldFetch, selectorsKey]);
+
+  const availableValues = useMemo<string[]>(() => {
+    const fromApi = fetchedLabels ?? [];
+    if (fetchError || (!isLoading && fromApi.length === 0 && seriesLabels.length > 0)) {
+      return seriesLabels;
+    }
+    return fromApi;
+  }, [fetchedLabels, seriesLabels, fetchError, isLoading]);
+
+  const availableLabels = useMemo<Array<ComboboxOption<string>>>(
+    () => availableValues.map((label) => ({ label, value: label })),
+    [availableValues]
+  );
+
+  const selectedLabels = useMemo<string[]>(() => {
+    if (override === null) {
+      return availableValues;
+    }
+    const availableSet = new Set(availableValues);
+    return override.filter((l) => availableSet.has(l));
+  }, [availableValues, override]);
+
+  const setSelectedLabels = useCallback((labels: string[]) => {
+    setOverride(labels);
+  }, []);
+
+  return { availableLabels, selectedLabels, setSelectedLabels, isLoading };
+}

--- a/src/components/ExportData/useExportSelectors.ts
+++ b/src/components/ExportData/useExportSelectors.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { PanelData } from '@grafana/data';
+
+import { PrometheusDatasource } from '../../datasource';
+import { PromQuery } from '../../types';
+
+import { extractMetricSelectors, MetricSelector } from './utils';
+
+interface UseExportSelectorsResult {
+  validSelectors: MetricSelector[];
+  selectedSelectors: string[];
+  toggleSelector: (selector: string) => void;
+}
+
+export function useExportSelectors(
+  datasource: PrometheusDatasource,
+  query: PromQuery,
+  panelData?: PanelData
+): UseExportSelectorsResult {
+  const resolvedExpr = useMemo(
+    () => datasource.getTemplateSrv().replace(query.expr, panelData?.request?.scopedVars),
+    [datasource, query.expr, panelData?.request?.scopedVars]
+  );
+
+  const validSelectors = useMemo(() => extractMetricSelectors(resolvedExpr), [resolvedExpr]);
+
+  const [selectedSelectors, setSelectedSelectors] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSelectedSelectors(validSelectors.map((s) => s.selector));
+  }, [validSelectors]);
+
+  const toggleSelector = useCallback((selector: string) => {
+    setSelectedSelectors((prev) =>
+      prev.includes(selector) ? prev.filter((s) => s !== selector) : [...prev, selector]
+    );
+  }, []);
+
+  return { validSelectors, selectedSelectors, toggleSelector };
+}

--- a/src/components/ExportData/useExportUrl.test.ts
+++ b/src/components/ExportData/useExportUrl.test.ts
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react';
+
+import { PrometheusDatasource } from '../../datasource';
+
+import { ExportOptions } from './types';
+import { useExportUrl } from './useExportUrl';
+
+const datasource = { uid: 'ds-uid' } as PrometheusDatasource;
+
+const baseOptions: ExportOptions = {
+  format: 'json',
+  timestampFormat: 'unix_s',
+  customLayout: 'YYYY-MM-DDThh:mm:ss.SSSZ',
+};
+
+const START_MS = 1_700_000_000_000;
+const END_MS = 1_700_003_600_000;
+
+describe('useExportUrl', () => {
+  it('returns canExport=false and empty url when there are no selectors', () => {
+    const { result } = renderHook(() =>
+      useExportUrl({
+        datasource,
+        selectors: [],
+        options: baseOptions,
+        selectedLabels: [],
+        startMs: START_MS,
+        endMs: END_MS,
+      })
+    );
+
+    expect(result.current.canExport).toBe(false);
+    expect(result.current.exportUrl).toBe('');
+    expect(result.current.exportFileName).toBe('');
+  });
+
+  it('builds a JSON export URL with match[] params and unix seconds for the range', () => {
+    const { result } = renderHook(() =>
+      useExportUrl({
+        datasource,
+        selectors: ['foo{bar="baz"}'],
+        options: baseOptions,
+        selectedLabels: [],
+        startMs: START_MS,
+        endMs: END_MS,
+      })
+    );
+
+    expect(result.current.canExport).toBe(true);
+    expect(result.current.exportUrl).toContain('api/datasources/uid/ds-uid/resources/api/v1/export?');
+    const query = result.current.exportUrl.split('?')[1];
+    const params = new URLSearchParams(query);
+    expect(params.getAll('match[]')).toEqual(['foo{bar="baz"}']);
+    expect(params.get('start')).toBe(String(START_MS / 1000));
+    expect(params.get('end')).toBe(String(END_MS / 1000));
+    expect(params.get('format')).toBeNull();
+    expect(result.current.exportFileName).toMatch(/^export-\d+\.jsonl$/);
+  });
+
+  it('builds a CSV export URL with format= encoding the timestamp format and selected labels', () => {
+    const { result } = renderHook(() =>
+      useExportUrl({
+        datasource,
+        selectors: ['metric'],
+        options: { ...baseOptions, format: 'csv', timestampFormat: 'rfc3339' },
+        selectedLabels: ['job', 'instance'],
+        startMs: START_MS,
+        endMs: END_MS,
+      })
+    );
+
+    expect(result.current.exportUrl).toContain('/api/v1/export/csv?');
+    const params = new URLSearchParams(result.current.exportUrl.split('?')[1]);
+    expect(params.get('format')).toBe('__timestamp__:rfc3339,__name__,job,instance,__value__');
+    expect(result.current.exportFileName).toMatch(/^export-\d+\.csv$/);
+  });
+
+  it('appends one match[] per selector and encodes the selector list in the multi-selector file name', () => {
+    const { result } = renderHook(() =>
+      useExportUrl({
+        datasource,
+        selectors: ['metric_a', 'metric_b{job="api"}'],
+        options: baseOptions,
+        selectedLabels: [],
+        startMs: START_MS,
+        endMs: END_MS,
+      })
+    );
+
+    const params = new URLSearchParams(result.current.exportUrl.split('?')[1]);
+    expect(params.getAll('match[]')).toEqual(['metric_a', 'metric_b{job="api"}']);
+    // File name encodes each selector and joins with `_`.
+    expect(result.current.exportFileName).toMatch(/^export-metric_a_metric_b%7Bjob%3D%22api%22%7D-\d+\.jsonl$/);
+  });
+});

--- a/src/components/ExportData/useExportUrl.ts
+++ b/src/components/ExportData/useExportUrl.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+
+import { PrometheusDatasource } from '../../datasource';
+
+import { FILE_FORMATS } from './constants';
+import { ExportOptions } from './types';
+import { buildCsvFormatString, buildExportParams, generateExportFileName, toUnixSeconds } from './utils';
+
+interface UseExportUrlArgs {
+  datasource: PrometheusDatasource;
+  selectors: string[];
+  options: ExportOptions;
+  selectedLabels: string[];
+  startMs: number;
+  endMs: number;
+}
+
+interface UseExportUrlResult {
+  exportUrl: string;
+  exportFileName: string;
+  canExport: boolean;
+}
+
+export function useExportUrl({
+  datasource,
+  selectors,
+  options,
+  selectedLabels,
+  startMs,
+  endMs,
+}: UseExportUrlArgs): UseExportUrlResult {
+  return useMemo<UseExportUrlResult>(() => {
+    const canExport = selectors.length > 0;
+    if (!canExport) {
+      return { exportUrl: '', exportFileName: '', canExport };
+    }
+    const formatConfig = FILE_FORMATS[options.format];
+    const csvFormat =
+      options.format === 'csv'
+        ? buildCsvFormatString({
+          timestampFormat: options.timestampFormat,
+          customLayout: options.customLayout,
+          selectedLabels,
+        })
+        : undefined;
+    const params = buildExportParams(
+      selectors,
+      toUnixSeconds(startMs),
+      toUnixSeconds(endMs),
+      options.format,
+      csvFormat
+    );
+    return {
+      exportUrl: `api/datasources/uid/${datasource.uid}/resources/${formatConfig.apiPath}?${params.toString()}`,
+      exportFileName: generateExportFileName(selectors, Date.now(), formatConfig.ext),
+      canExport,
+    };
+  }, [datasource.uid, selectors, startMs, endMs, options, selectedLabels]);
+}

--- a/src/components/ExportData/utils.ts
+++ b/src/components/ExportData/utils.ts
@@ -10,6 +10,60 @@ import {
   VectorSelector,
 } from 'lezer-metricsql';
 
+import { convertLDMLLayoutToGoTimeLayout } from '../../utils/convertLDMLLayoutToGoTimeLayout';
+
+import { ExportFormat, TimestampFormat } from './types';
+
+export const toUnixSeconds = (milliseconds: number): number => Math.floor(milliseconds / 1000);
+
+interface BuildCsvFormatStringArgs {
+  timestampFormat: TimestampFormat;
+  customLayout: string;
+  selectedLabels: string[];
+}
+
+export function buildCsvFormatString({
+  timestampFormat,
+  customLayout,
+  selectedLabels,
+}: BuildCsvFormatStringArgs): string {
+  let tsFormat: string = timestampFormat;
+  if (timestampFormat === 'custom') {
+    tsFormat = `custom:${convertLDMLLayoutToGoTimeLayout(customLayout)}`;
+  }
+  let fmt = `__timestamp__:${tsFormat},__name__`;
+  if (selectedLabels.length > 0) {
+    fmt += ',' + selectedLabels.join(',');
+  }
+  fmt += ',__value__';
+  return fmt;
+}
+
+export function buildExportParams(
+  selectors: string[],
+  startSec: number,
+  endSec: number,
+  format: ExportFormat,
+  csvFormat?: string
+): URLSearchParams {
+  const params = new URLSearchParams();
+  selectors.forEach((selector) => params.append('match[]', selector));
+  params.append('start', startSec.toString());
+  params.append('end', endSec.toString());
+  if (format === 'csv' && csvFormat) {
+    params.append('format', csvFormat);
+  }
+  return params;
+}
+
+export function generateExportFileName(selectors: string[], timestamp: number, ext: string): string {
+  if (selectors.length === 1) {
+    return `export-${timestamp}.${ext}`;
+  }
+  const selectorStr = selectors.map((selector) => encodeURIComponent(selector)).join('_');
+  return `export-${selectorStr}-${timestamp}.${ext}`;
+}
+
 export interface MetricSelector {
   /** Full text of the vector selector, e.g. 'http_requests_total{job="api"}' */
   selector: string;


### PR DESCRIPTION
### Describe Your Changes

Previously the labels picker in the Export Data CSV options was populated from `panelData.series`, so opening the dialog before the query had been executed (or on a query that returned no data) left the picker empty.

Labels are now fetched on demand via `datasource.getTagKeys` (which goes to `/api/v1/labels?match[]=...` or `/api/v1/series` depending on `useOptimizedLabelsApi`) and exposed through a new `useExportLabels` hook. All selectors are passed in a single call so requests fan out in parallel under the hood; on error the hook falls back to labels found in the panel response.

Selection model:
- All available labels are selected by default.
- Edits made by the user are preserved across modal close/reopen for the lifetime of the button; labels that disappear when the query changes are dropped automatically.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty Labels picker in Export Data CSV by fetching label keys from the datasource instead of the panel response. Labels load on demand, default to all, and preserve user edits across modal reopen.

- **Bug Fixes**
  - Fetch label keys via `datasource.getTagKeys` for current selectors; works before the query runs or when it returns no data.
  - Send all selectors in one call (parallelized under the hood) and fall back to `panelData.series` labels on error.

- **Refactors**
  - Simplified `ExportDataModal` and extracted `CsvOptionsFields`, `SelectorsField`, `TimeRangeField`.
  - Added `useExportLabels`, `useExportSelectors`, `useExportUrl` hooks; moved URL/CSV format/file-name helpers to `utils.ts` with tests.

<sup>Written for commit 0514fc166286fbd90d143ee542a542a5cd88dda7. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/516?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

