### PR TITLE
chore: update CHANGELOG for v0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+## v0.25.0
+
 * FEATURE: allow exporting label-only selectors such as `{job="prometheus"}` from the Export Data dialog. Previously the export button required a named metric in the query. See [#471](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/471). Thanks to @dmedovich for contributing.
 * FEATURE: move the timestamp column first in exported CSV files and change the download to a direct link to avoid loading large datasets into the browser. Column order is controlled via the `format` parameter. See [#471](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/471). Thanks to @dmedovich for contributing.
 * FEATURE: provide a plugin binary for OpenBSD. Thanks to @ledeuns for contributing.


### PR DESCRIPTION
### Describe Your Changes

update CHANGELOG for v0.25.0 release

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare CHANGELOG for v0.25.0 by adding the version header and grouping the current entries under this release: label-only query export, CSV timestamp-first direct download, and an OpenBSD plugin binary.

<sup>Written for commit b6dbd00c9ed431abe1af3b628a0592a2d94e3048. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

