### PR TITLE
fix: trigger autocomplete after a middle comma in label selectors (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix autocomplete not triggering when the cursor is placed after a middle comma inside a label selector (e.g. `metric{job="j1",^host="h2"}`). See [#522](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/522).
+
 ## v0.25.0
 
 * FEATURE: allow exporting label-only selectors such as `{job="prometheus"}` from the Export Data dialog. Previously the export button required a named metric in the query. See [#471](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/471). Thanks to @dmedovich for contributing.

--- a/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -1,0 +1,56 @@
+import { getCompletions, DataProvider } from './completions';
+import { Situation } from './situation';
+
+function makeDataProvider(): DataProvider {
+  return {
+    getHistory: jest.fn().mockResolvedValue([]),
+    getAllMetricNames: jest.fn().mockResolvedValue([]),
+    getAllWithTemplates: jest.fn().mockResolvedValue([]),
+    getAllLabelNames: jest.fn().mockResolvedValue(['instance', 'job']),
+    getLabelValues: jest.fn().mockResolvedValue([]),
+    getSeries: jest.fn().mockResolvedValue({ job: ['j1'], host: ['h2'], instance: ['i1'] }),
+  };
+}
+
+describe('getCompletions', () => {
+  it('suggests label names with a `=` suffix in a label selector', async () => {
+    const situation: Situation = {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      metricName: 'something',
+      otherLabels: [{ name: 'job', value: 'j1', op: '=' }],
+    };
+
+    const completions = await getCompletions(situation, makeDataProvider());
+    const labelNames = completions.filter((c) => c.type === 'LABEL_NAME');
+
+    expect(labelNames).toEqual([
+      expect.objectContaining({ label: 'host', insertText: 'host=', triggerOnInsert: true }),
+      expect.objectContaining({ label: 'instance', insertText: 'instance=', triggerOnInsert: true }),
+    ]);
+    expect(labelNames[0].isSnippet).toBeFalsy();
+  });
+
+  it('suggests label names as a snippet with a trailing comma when a matcher follows the cursor', async () => {
+    const situation: Situation = {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      metricName: 'something',
+      otherLabels: [
+        { name: 'job', value: 'j1', op: '=' },
+        { name: 'host', value: 'h2', op: '=' },
+      ],
+      hasMatcherAfterCursor: true,
+    };
+
+    const completions = await getCompletions(situation, makeDataProvider());
+    const labelNames = completions.filter((c) => c.type === 'LABEL_NAME');
+
+    expect(labelNames).toEqual([
+      expect.objectContaining({
+        label: 'instance',
+        insertText: 'instance=$0,',
+        triggerOnInsert: true,
+        isSnippet: true,
+      }),
+    ]);
+  });
+});

--- a/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -40,6 +40,7 @@ type Completion = {
   detail?: string;
   documentation?: string;
   triggerOnInsert?: boolean;
+  isSnippet?: boolean;
 };
 
 type Metric = {
@@ -165,6 +166,7 @@ async function getLabelNamesForCompletions(
   metric: string | undefined,
   suffix: string,
   triggerOnInsert: boolean,
+  isSnippet: boolean,
   otherLabels: Label[],
   dataProvider: DataProvider
 ): Promise<Completion[]> {
@@ -174,6 +176,7 @@ async function getLabelNamesForCompletions(
     label: text,
     insertText: `${text}${suffix}`,
     triggerOnInsert,
+    isSnippet,
   }))
   const withTemplatesCompletions = await getAllWithTemplatesCompletions(dataProvider);
   const withTemplatesCompletionsLabels = withTemplatesCompletions.filter((c) => {
@@ -186,16 +189,21 @@ async function getLabelNamesForCompletions(
 async function getLabelNamesForSelectorCompletions(
   metric: string | undefined,
   otherLabels: Label[],
+  hasMatcherAfterCursor: boolean,
   dataProvider: DataProvider
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions(metric, '=', true, otherLabels, dataProvider);
+  // when another label-matcher follows the cursor, we have to insert
+  // a `,` after the new label-matcher to keep the query valid,
+  // and we use a snippet to keep the cursor before that `,`
+  const suffix = hasMatcherAfterCursor ? '=$0,' : '=';
+  return getLabelNamesForCompletions(metric, suffix, true, hasMatcherAfterCursor, otherLabels, dataProvider);
 }
 async function getLabelNamesForByCompletions(
   metric: string | undefined,
   otherLabels: Label[],
   dataProvider: DataProvider
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions(metric, '', false, otherLabels, dataProvider);
+  return getLabelNamesForCompletions(metric, '', false, false, otherLabels, dataProvider);
 }
 
 async function getLabelValues(
@@ -244,7 +252,12 @@ export async function getCompletions(situation: Situation, dataProvider: DataPro
       return [...historyCompletions, ...FUNCTION_COMPLETIONS, ...metricNames];
     }
     case 'IN_LABEL_SELECTOR_NO_LABEL_NAME':
-      return getLabelNamesForSelectorCompletions(situation.metricName, situation.otherLabels, dataProvider);
+      return getLabelNamesForSelectorCompletions(
+        situation.metricName,
+        situation.otherLabels,
+        situation.hasMatcherAfterCursor ?? false,
+        dataProvider
+      );
     case 'IN_GROUPING':
       return getLabelNamesForByCompletions(situation.metricName, situation.otherLabels, dataProvider);
     case 'IN_LABEL_SELECTOR_WITH_LABEL_NAME':

--- a/src/components/monaco-query-field/monaco-completion-provider/index.test.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.test.ts
@@ -1,0 +1,105 @@
+import type { Monaco, monacoTypes } from '@grafana/ui';
+
+import { DataProvider } from './completions';
+
+import { getCompletionProvider } from './index';
+
+const INSERT_AS_SNIPPET = 4;
+
+const monacoMock = {
+  Range: {
+    lift: (range: unknown) => range,
+    fromPositions: (position: { lineNumber: number; column: number }) => ({
+      startLineNumber: position.lineNumber,
+      endLineNumber: position.lineNumber,
+      startColumn: position.column,
+      endColumn: position.column,
+    }),
+  },
+  languages: {
+    CompletionItemKind: {
+      Unit: 0,
+      Variable: 1,
+      Snippet: 2,
+      Enum: 3,
+      EnumMember: 4,
+      Constructor: 5,
+      Constant: 6,
+    },
+    CompletionItemInsertTextRule: {
+      InsertAsSnippet: INSERT_AS_SNIPPET,
+    },
+  },
+} as unknown as Monaco;
+
+function makeModel(text: string): monacoTypes.editor.ITextModel {
+  return {
+    getValue: () => text,
+    getOffsetAt: (position: { lineNumber: number; column: number }) => position.column - 1,
+    getWordAtPosition: () => null,
+    getLineContent: () => text,
+  } as unknown as monacoTypes.editor.ITextModel;
+}
+
+function makeDataProvider(): DataProvider {
+  return {
+    getHistory: jest.fn().mockResolvedValue([]),
+    getAllMetricNames: jest.fn().mockResolvedValue([]),
+    getAllWithTemplates: jest.fn().mockResolvedValue([]),
+    getAllLabelNames: jest.fn().mockResolvedValue([]),
+    getLabelValues: jest.fn().mockResolvedValue([]),
+    getSeries: jest.fn().mockResolvedValue({ job: ['j1'], host: ['h2'], instance: ['i1'] }),
+  };
+}
+
+describe('getCompletionProvider', () => {
+  it('marks label-name suggestions after a middle comma as snippets', async () => {
+    const text = 'something{job="j1",host="h2"}';
+    const position = {
+      lineNumber: 1,
+      column: 'something{job="j1",'.length + 1,
+    } as monacoTypes.Position;
+
+    const provider = getCompletionProvider(monacoMock, makeDataProvider());
+    const result = await provider.provideCompletionItems(
+      makeModel(text),
+      position,
+      {} as monacoTypes.languages.CompletionContext,
+      {} as monacoTypes.CancellationToken
+    );
+
+    const suggestions = result?.suggestions ?? [];
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        label: 'instance',
+        insertText: 'instance=$0,',
+        insertTextRules: INSERT_AS_SNIPPET,
+      }),
+    ]);
+  });
+
+  it('does not mark label-name suggestions at the end of a selector as snippets', async () => {
+    const text = 'something{job="j1",host="h2",}';
+    const position = {
+      lineNumber: 1,
+      column: 'something{job="j1",host="h2",'.length + 1,
+    } as monacoTypes.Position;
+
+    const provider = getCompletionProvider(monacoMock, makeDataProvider());
+    const result = await provider.provideCompletionItems(
+      makeModel(text),
+      position,
+      {} as monacoTypes.languages.CompletionContext,
+      {} as monacoTypes.CancellationToken
+    );
+
+    const suggestions = result?.suggestions ?? [];
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        label: 'instance',
+        insertText: 'instance=',
+        insertTextRules: undefined,
+      }),
+    ]);
+  });
+});

--- a/src/components/monaco-query-field/monaco-completion-provider/index.test.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.test.ts
@@ -32,11 +32,11 @@ const monacoMock = {
   },
 } as unknown as Monaco;
 
-function makeModel(text: string): monacoTypes.editor.ITextModel {
+function makeModel(text: string, wordAtPosition: monacoTypes.editor.IWordAtPosition | null = null): monacoTypes.editor.ITextModel {
   return {
     getValue: () => text,
     getOffsetAt: (position: { lineNumber: number; column: number }) => position.column - 1,
-    getWordAtPosition: () => null,
+    getWordAtPosition: () => wordAtPosition,
     getLineContent: () => text,
   } as unknown as monacoTypes.editor.ITextModel;
 }
@@ -76,6 +76,80 @@ describe('getCompletionProvider', () => {
         insertTextRules: INSERT_AS_SNIPPET,
       }),
     ]);
+  });
+
+  it('uses a zero-width range when the cursor is right before the next word', async () => {
+    const text = 'something{job="j1",host="h2"}';
+    const cursorColumn = 'something{job="j1",'.length + 1;
+    const position = {
+      lineNumber: 1,
+      column: cursorColumn,
+    } as monacoTypes.Position;
+    // monaco returns "host" here because the cursor touches its start boundary
+    const wordAtPosition: monacoTypes.editor.IWordAtPosition = {
+      word: 'host',
+      startColumn: cursorColumn,
+      endColumn: cursorColumn + 'host'.length,
+    };
+
+    const provider = getCompletionProvider(monacoMock, makeDataProvider());
+    const result = await provider.provideCompletionItems(
+      makeModel(text, wordAtPosition),
+      position,
+      {} as monacoTypes.languages.CompletionContext,
+      {} as monacoTypes.CancellationToken
+    );
+
+    const suggestions = result?.suggestions ?? [];
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        label: 'instance',
+        range: {
+          startLineNumber: 1,
+          endLineNumber: 1,
+          startColumn: cursorColumn,
+          endColumn: cursorColumn,
+        },
+      }),
+    ]);
+  });
+
+  it('replaces the current word when the cursor is at its end', async () => {
+    const text = 'something{ho}';
+    const wordStartColumn = 'something{'.length + 1;
+    const position = {
+      lineNumber: 1,
+      column: wordStartColumn + 'ho'.length, // after the typed prefix: ho^
+    } as monacoTypes.Position;
+    const wordAtPosition: monacoTypes.editor.IWordAtPosition = {
+      word: 'ho',
+      startColumn: wordStartColumn,
+      endColumn: wordStartColumn + 'ho'.length,
+    };
+
+    // "ho" resolves to the label-value situation for label "ho",
+    // and values for a metric are looked up via getSeries
+    const dataProvider = makeDataProvider();
+    dataProvider.getSeries = jest.fn().mockResolvedValue({ ho: ['h1'] });
+
+    const provider = getCompletionProvider(monacoMock, dataProvider);
+    const result = await provider.provideCompletionItems(
+      makeModel(text, wordAtPosition),
+      position,
+      {} as monacoTypes.languages.CompletionContext,
+      {} as monacoTypes.CancellationToken
+    );
+
+    const suggestions = result?.suggestions ?? [];
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const suggestion of suggestions) {
+      expect(suggestion.range).toEqual({
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: wordStartColumn,
+        endColumn: wordStartColumn + 'ho'.length,
+      });
+    }
   });
 
   it('does not mark label-name suggestions at the end of a selector as snippets', async () => {

--- a/src/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -127,6 +127,9 @@ export function getCompletionProvider(
         documentation: { value: item.documentation } as IMarkdownString,
         sortText: index.toString().padStart(maxIndexDigits, '0'), // to force the order we have
         range: item.type === CompletionType.metricName ? metricNameRange : range,
+        insertTextRules: item.isSnippet
+          ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+          : undefined,
         command: item.triggerOnInsert
           ? {
             id: 'editor.action.triggerSuggest',

--- a/src/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -95,8 +95,11 @@ export function getCompletionProvider(
     position: monacoTypes.Position
   ): monacoTypes.languages.ProviderResult<monacoTypes.languages.CompletionList> => {
     const word = model.getWordAtPosition(position);
+    // when the cursor only touches the start boundary of the word
+    // (e.g. `{job="j1",^host="h2"}`), the user has typed no prefix of it,
+    // so we must insert at the cursor instead of replacing the word
     const range =
-      word != null
+      word != null && position.column > word.startColumn
         ? monaco.Range.lift({
           startLineNumber: position.lineNumber,
           endLineNumber: position.lineNumber,

--- a/src/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -109,6 +109,66 @@ describe('situation', () => {
     });
   });
 
+  it('handles label names after a middle comma', () => {
+    assertSituation('something{job="j1",^host="h2"}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      hasMatcherAfterCursor: true,
+      metricName: 'something',
+      otherLabels: [
+        { name: 'job', value: 'j1', op: '=' },
+        { name: 'host', value: 'h2', op: '=' },
+      ],
+    });
+
+    // with whitespace around the cursor
+    assertSituation('something{job="j1", ^ host="h2"}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      hasMatcherAfterCursor: true,
+      metricName: 'something',
+      otherLabels: [
+        { name: 'job', value: 'j1', op: '=' },
+        { name: 'host', value: 'h2', op: '=' },
+      ],
+    });
+
+    // three labels, cursor after the first comma (nested LabelMatchList)
+    assertSituation('something{a="1",^b="2",c="3"}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      hasMatcherAfterCursor: true,
+      metricName: 'something',
+      otherLabels: [
+        { name: 'a', value: '1', op: '=' },
+        { name: 'b', value: '2', op: '=' },
+        { name: 'c', value: '3', op: '=' },
+      ],
+    });
+
+    // three labels, cursor after the second comma
+    assertSituation('something{a="1",b="2",^c="3"}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      hasMatcherAfterCursor: true,
+      metricName: 'something',
+      otherLabels: [
+        { name: 'a', value: '1', op: '=' },
+        { name: 'b', value: '2', op: '=' },
+        { name: 'c', value: '3', op: '=' },
+      ],
+    });
+
+    // without a metric name
+    assertSituation('{job="j1",^host="h2"}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      hasMatcherAfterCursor: true,
+      otherLabels: [
+        { name: 'job', value: 'j1', op: '=' },
+        { name: 'host', value: 'h2', op: '=' },
+      ],
+    });
+
+    // cursor before the comma must not trigger label-name suggestions
+    assertSituation('something{job="j1"^,host="h2"}', null);
+  });
+
   it('handles label values', () => {
     assertSituation('something{job=^}', {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',

--- a/src/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/src/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -159,6 +159,9 @@ export type Situation =
     type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME';
     metricName?: string;
     otherLabels: Label[];
+    // true when another label-matcher follows the cursor,
+    // like in `something{job="j1",^host="h2"}`
+    hasMatcherAfterCursor?: boolean;
   }
   | {
     type: 'IN_GROUPING';
@@ -188,6 +191,10 @@ const RESOLVERS: Resolver[] = [
   {
     path: [LabelMatchers, VectorSelector],
     fun: resolveLabelKeysWithEquals,
+  },
+  {
+    path: [LabelMatchList],
+    fun: resolveLabelKeysAfterComma,
   },
   {
     path: [MetricsQL],
@@ -492,13 +499,19 @@ function resolveLabelKeysWithEquals(node: SyntaxNode, text: string, pos: number)
     }
   }
 
-  const metricNameNode = walk(node, [
+  return buildInLabelSelectorSituation(node, text);
+}
+
+type InLabelSelectorNoLabelNameSituation = Extract<Situation, { type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME' }>;
+
+function buildInLabelSelectorSituation(labelMatchersNode: SyntaxNode, text: string): InLabelSelectorNoLabelNameSituation {
+  const metricNameNode = walk(labelMatchersNode, [
     ['parent', VectorSelector],
     ['firstChild', MetricIdentifier],
     ['firstChild', Identifier],
   ]);
 
-  const otherLabels = getLabels(node, text);
+  const otherLabels = getLabels(labelMatchersNode, text);
 
   if (metricNameNode === null) {
     // we are probably in a situation without a metric name.
@@ -515,6 +528,58 @@ function resolveLabelKeysWithEquals(node: SyntaxNode, text: string, pos: number)
     metricName,
     otherLabels,
   };
+}
+
+// for example `something{job="j1",^host="h2"}`
+// the cursor is inside a LabelMatchList, after a "middle" comma.
+
+// we walk up through the nested LabelMatchList parents,
+// as soon as we reach LabelMatchers, we stop
+function resolveLabelKeysAfterComma(node: SyntaxNode, text: string, pos: number): Situation | null {
+  let listNode = node;
+  let labelMatchersNode: SyntaxNode | null = null;
+  while (labelMatchersNode === null) {
+    const p = listNode.parent;
+    if (p === null) {
+      return null;
+    }
+
+    switch (p.type.id) {
+      case LabelMatchList:
+        // we keep looping
+        listNode = p;
+        continue;
+      case LabelMatchers:
+        // we reached the end, we can stop the loop
+        labelMatchersNode = p;
+        continue;
+      default:
+        // we reached some other node, we stop
+        return null;
+    }
+  }
+
+  if (subTreeHasError(labelMatchersNode)) {
+    return null;
+  }
+
+  // the cursor must be after a `,` character:
+  // the area between the end of the previous label-matcher
+  // and the cursor-pos must contain a `,`
+  // (this keeps `something{job="j1"^,host="h2"}` returning null)
+  const child = node.firstChild;
+  if (child === null) {
+    return null;
+  }
+
+  const textToCheck = text.slice(child.to, pos);
+  if (!textToCheck.includes(',')) {
+    return null;
+  }
+
+  // in this situation the grammar guarantees that another
+  // label-matcher follows the cursor
+  return { ...buildInLabelSelectorSituation(labelMatchersNode, text), hasMatcherAfterCursor: true };
 }
 
 // we find the first error-node in the tree that is at the cursor-position.


### PR DESCRIPTION
Related issue: #522 

### Describe Your Changes

Fixed autocomplete not triggering when the cursor is placed after a middle comma inside a label selector (e.g. `metric{job="j1",^host="h2"}`).

https://github.com/user-attachments/assets/315800a1-e234-4b80-b117-f9ae9a392c70



### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes autocomplete when the cursor is after a middle comma in label selectors (e.g. `metric{job="j1",^host="h2"}`), and prevents replacing the next label name when accepting suggestions. Addresses #522.

- **Bug Fixes**
  - Added a `LabelMatchList` resolver to detect label-name position after a middle comma and set `hasMatcherAfterCursor`.
  - When another matcher follows the cursor, insert label names as a snippet (`name=$0,`); otherwise use `name=`.
  - Enabled snippet insertion in `Monaco` and used a zero-width range when the cursor touches the next word start, so suggestions insert before it instead of replacing.
  - Updated tests for situations, completion provider, and completions; added CHANGELOG entry.

<sup>Written for commit f7fc2e1e425a4c78074ad23dd8ccf89adaaf8aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

