### PR TITLE
fix: preserve millisecond precision in instant query time

### DIFF
--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -525,6 +525,59 @@ func TestDatasourceQueryRequestWithRetry(t *testing.T) {
 	expErr("EOF") // 3, 4 - retries
 }
 
+func TestDatasourceQueryRequest_PreservesInstantQueryMilliseconds(t *testing.T) {
+	var gotTime string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTime = r.URL.Query().Get("time")
+		_, err := w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1583786142, "1"]}}`))
+		if err != nil {
+			t.Fatalf("error write response: %s", err)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	ds := NewDatasource()
+	pluginCtx := backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			URL:      srv.URL,
+			JSONData: []byte(`{"httpMethod":"GET","customQueryParameters":""}`),
+		},
+	}
+
+	_, err := ds.QueryData(ctx, &backend.QueryDataRequest{
+		PluginContext: pluginCtx,
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: instantQueryPath,
+				TimeRange: backend.TimeRange{
+					From: time.Unix(1670226733, 0),
+					To:   time.UnixMilli(1670226793123),
+				},
+				JSON: []byte(`{
+    "refId": "A",
+    "instant": true,
+    "range": false,
+    "interval": "10s",
+    "intervalMs": 10000,
+    "timeInterval": "",
+    "expr": "sum(vm_http_request_total)",
+    "legendFormat": "__auto"
+}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotTime != "1670226793.123" {
+		t.Fatalf("unexpected time query parameter: got %q want %q", gotTime, "1670226793.123")
+	}
+}
+
 func TestDatasource_checkAlertingRequest(t *testing.T) {
 	type opts struct {
 		headers map[string]string

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -92,7 +92,7 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 				values.Add(k, v)
 			}
 		}
-		values.Set("time", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
+		values.Set("time", formatPromTimestamp(q.TimeRange.To))
 	}
 	if q.Trace > 0 {
 		values.Set("trace", strconv.Itoa(q.Trace))
@@ -102,6 +102,15 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 
 	u.RawQuery = values.Encode()
 	return u.String(), nil
+}
+
+func formatPromTimestamp(t time.Time) string {
+	seconds := t.Unix()
+	millis := t.Nanosecond() / int(time.Millisecond)
+	if millis == 0 {
+		return strconv.FormatInt(seconds, 10)
+	}
+	return fmt.Sprintf("%d.%03d", seconds, millis)
 }
 
 // withIntervalVariable checks does query has interval variable

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -116,6 +116,27 @@ func TestQuery_getQueryURL(t *testing.T) {
 	}
 	f(o)
 
+	// instant query should preserve millisecond precision in time param
+	o = opts{
+		RefID:         "1",
+		Instant:       true,
+		Range:         false,
+		Interval:      "20s",
+		IntervalMs:    0,
+		TimeInterval:  "5s",
+		Expr:          "up",
+		MaxDataPoints: 20000,
+		getTimeRange: func() TimeRange {
+			from := time.Unix(1670226733, 0)
+			to := time.UnixMilli(1670226793123)
+			return TimeRange{From: from, To: to}
+		},
+		rawURL:  "http://127.0.0.1:8428",
+		wantErr: false,
+		want:    "http://127.0.0.1:8428/api/v1/query?query=up&step=20s&time=1670226793.123",
+	}
+	f(o)
+
 	// $__rate_interval query with interval
 	o = opts{
 		RefID:         "1",


### PR DESCRIPTION
Related issue: #376

### Describe Your Changes

Instant queries were truncating the backend `time` param to whole seconds, so a Grafana end time like `1670226793123` got sent upstream as `1670226793`.

This is pretty easy to hit in real life, because Grafana request ranges use millisecond timestamps, and the Prometheus compatible query API accepts unix seconds with optional decimal places for sub-second precision. So yeah, no weird setup needed.

This patch keeps millisecond precision for the instant-query `time` param only. Range query handling stays the same.

Repro:
1. Build an instant query with `TimeRange.To = time.UnixMilli(1670226793123)`.
2. Before this patch, `getQueryURL()` returns `.../api/v1/query?...&time=1670226793`.
3. After this patch, it returns `...&time=1670226793.123`.

Added one URL-level test and one `QueryData` test, so we check the actual upstream request too.

### Checklist

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves millisecond precision in instant query time so Grafana timestamps (ms) are sent upstream correctly (e.g., 1670226793.123 instead of 1670226793). Fixes #376.

- Bug Fixes
  - Instant queries now format `time` with milliseconds when present; range queries unchanged.
  - Added `formatPromTimestamp` to include ms only when needed.
  - Tests cover URL formatting and upstream request to ensure `time=1670226793.123`.

<sup>Written for commit 1ccbc6960bee60a61630042c4062c9e44a5d3ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/victoriametrics-datasource/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

