### PR TITLE
fix: keep the range vector  when the query builder parses range functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* BUGFIX: keep the range vector (e.g. `[24h]`) when the query builder parses `holt_winters`, `predict_linear`, `idelta`, `deriv` and `resets`. Previously, the Range field disappeared after reopening the panel or switching from Code to Builder view, and editing other parameters produced an invalid query. See [#528](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/528).
 * BUGFIX: fix autocomplete not triggering when the cursor is placed after a middle comma inside a label selector (e.g. `metric{job="j1",^host="h2"}`). See [#522](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/522).
 
 ## v0.25.0

--- a/src/querybuilder/parsing.test.ts
+++ b/src/querybuilder/parsing.test.ts
@@ -163,6 +163,18 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it.each([
+    ['holt_winters(metric[5m], 0.5, 0.5)', { id: 'holt_winters', params: ['5m', 0.5, 0.5] }],
+    ['predict_linear(metric[5m], 60)', { id: 'predict_linear', params: ['5m', 60] }],
+    ['idelta(metric[5m])', { id: 'idelta', params: ['5m'] }],
+    ['deriv(metric[5m])', { id: 'deriv', params: ['5m'] }],
+    ['resets(metric[5m])', { id: 'resets', params: ['5m'] }],
+  ])('keeps the range vector when parsing %s', (query, operation) => {
+    expect(buildVisualQueryFromString(query)).toEqual(
+      noErrors({ metric: 'metric', labels: [], operations: [operation] })
+    );
+  });
+
   it('parses query with aggregation by labels', () => {
     const visQuery = {
       metric: 'metric_name',

--- a/src/querybuilder/parsing.ts
+++ b/src/querybuilder/parsing.ts
@@ -28,7 +28,7 @@ import {
 } from 'lezer-metricsql';
 
 import { binaryScalarOperatorToOperatorName } from './binaryScalarOperations';
-import { overTimeFunctionNames }  from './metricsql-functions/aggregations/overTime';
+import { addOperationWithRangeVector, getOperationDefinitions } from './operations';
 import {
   ErrorId,
   ErrorName,
@@ -196,7 +196,12 @@ function getLabel(
   };
 }
 
-const rangeFunctions = ['changes', 'rate', 'irate', 'increase', 'delta', ...overTimeFunctionNames];
+// Functions whose first argument is a range vector (e.g. `rate(m[5m])`)
+const rangeVectorFunctionNames = new Set(
+  getOperationDefinitions()
+    .filter((def) => def.addOperationHandler === addOperationWithRangeVector)
+    .map((def) => def.id)
+);
 
 /**
  * Handle function call which is usually and identifier and its body > arguments.
@@ -218,7 +223,7 @@ function handleFunction(expr: string, node: SyntaxNode, context: InternalContext
   // - interval is not part of the function args per promQL grammar, but we model it as argument for the function in
   //   the query model.
   // - it is easier to handle template variables this way as template variable is an error for the parser
-  if (rangeFunctions.includes(funcName) || funcName.endsWith('_over_time')) {
+  if (rangeVectorFunctionNames.has(funcName) || funcName.endsWith('_over_time')) {
     let match = getString(expr, node).match(/(?<!\{[^}]*)\[(.+?)](?![^{]*})/);
     if (match?.[1]) {
       interval = match[1];


### PR DESCRIPTION
Previously, the Range field disappeared after reopening the panel or switching from Code to Builder view, and editing other parameters produced an invalid query

Related issue: #528 

### Describe Your Changes
Keep the range vector (e.g. `[24h]`) when the query builder parses `holt_winters`, `predict_linear`, `idelta`, `deriv` and `resets`. Previously, the Range field disappeared after reopening the panel or switching from Code to Builder view, and editing other parameters produced an invalid query.


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
