### PR TITLE
fix(variable query editor): fix client-side crash when opening the variable editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix client-side crash when opening the variable editor with the `Label values` query type on Grafana 13.x. See [#532](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/532).
+
 ## v0.25.1
 
 * BUGFIX: keep the range vector (e.g. `[24h]`) when the query builder parses `holt_winters`, `predict_linear`, `idelta`, `deriv` and `resets`. Previously, the Range field disappeared after reopening the panel or switching from Code to Builder view, and editing other parameters produced an invalid query. See [#528](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/528).

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-virtual-modules": "^0.6.2"
   },
   "resolutions": {
-    "@grafana/plugin-ui": "0.15.0",
+    "@grafana/plugin-ui": "0.16.0",
     "@lezer/common": "1.2.3",
     "@lezer/highlight": "1.2.1",
     "@lezer/lr": "1.4.2",
@@ -124,7 +124,6 @@
     "@grafana/aws-sdk": "^0.10.3",
     "@grafana/data": "^13.0.1",
     "@grafana/i18n": "^13.0.1",
-    "@grafana/plugin-ui": "^0.15.0",
     "@grafana/runtime": "^13.0.1",
     "@grafana/schema": "^13.0.1",
     "@grafana/ui": "^13.0.1",

--- a/src/querybuilder/components/LabelFilterItem.tsx
+++ b/src/querybuilder/components/LabelFilterItem.tsx
@@ -20,9 +20,9 @@ import React, { useState } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { AccessoryButton, InputGroup } from '@grafana/plugin-ui';
 import { AsyncSelect, Select } from '@grafana/ui';
 
+import { AccessoryButton, InputGroup } from '../../components/QueryEditor';
 import { truncateResult } from '../../language_utils';
 import { QueryBuilderLabelFilter } from '../shared/types';
 

--- a/src/querybuilder/components/LabelFilters.tsx
+++ b/src/querybuilder/components/LabelFilters.tsx
@@ -20,10 +20,9 @@ import { isEqual } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorFieldGroup, EditorField } from '@grafana/plugin-ui';
 import { InlineFieldRow, InlineLabel } from '@grafana/ui';
 
-import { EditorList } from '../../components/QueryEditor';
+import { EditorField, EditorFieldGroup, EditorList } from '../../components/QueryEditor';
 import { QueryBuilderLabelFilter } from '../shared/types';
 
 import { LabelFilterItem } from './LabelFilterItem';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,9 +2392,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-ui@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@grafana/plugin-ui@npm:0.15.0"
+"@grafana/plugin-ui@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@grafana/plugin-ui@npm:0.16.0"
   dependencies:
     "@emotion/css": "npm:11.13.5"
     "@hello-pangea/dnd": "npm:17.0.0"
@@ -2415,7 +2415,9 @@ __metadata:
     "@testing-library/jest-dom": ">=5.16.5"
     "@testing-library/react": ">=15.0.2"
     "@testing-library/user-event": ">=14.5.2"
-  checksum: 10c0/89bea1324812df19a59aa739da1adfa24a58d8191d15c1c52cd702b60c5d70c514a28dd2d821398f35e30a926d7cc981e8233ae806610cf905400510ab40a01c
+    react: ">=18.2.0"
+    react-dom: ">=18.2.0"
+  checksum: 10c0/19df22d4c6a527078dc848138ce797ee9e981a39df7c13f03d9fbee6435c7f0d7d9666564d036214eb77a35de4d4eb770ae037359bab99d87405eaf0105ae673
   languageName: node
   linkType: hard
 
@@ -13683,7 +13685,6 @@ __metadata:
     "@grafana/e2e-selectors": "npm:^13.0.1"
     "@grafana/eslint-config": "npm:^9.0.0"
     "@grafana/i18n": "npm:^13.0.1"
-    "@grafana/plugin-ui": "npm:^0.15.0"
     "@grafana/runtime": "npm:^13.0.1"
     "@grafana/schema": "npm:^13.0.1"
     "@grafana/tsconfig": "npm:^2.1.0"


### PR DESCRIPTION
Related issue: #532 

### Describe Your Changes

Fix client-side crash when opening the variable editor with the `Label values` query type on Grafana 13.x by replacing components from `@grafana/plugin-ui` to `../../components/QueryEditor`.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
